### PR TITLE
Building Relocation working

### DIFF
--- a/src/CSM.csproj
+++ b/src/CSM.csproj
@@ -64,6 +64,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Commands\BuildingCreatedCommand.cs" />
+    <Compile Include="Commands\BuildingRelocationCommand.cs" />
     <Compile Include="Commands\BuildingRemovedCommand.cs" />
     <Compile Include="Commands\ClientConnectCommand.cs" />
     <Compile Include="Commands\ClientDisconnectCommand.cs" />

--- a/src/Commands/BuildingRelocationCommand.cs
+++ b/src/Commands/BuildingRelocationCommand.cs
@@ -1,0 +1,24 @@
+﻿using ProtoBuf;
+using UnityEngine;
+
+
+namespace CSM.Commands
+{
+	[ProtoContract]
+	public class BuildingRelocationCommand : CommandBase
+	{
+		[ProtoMember(1)]
+		public Vector3 NewPosition { get; set; }
+
+		[ProtoMember(2)]
+		public Vector3 OldPosition { get; set; }
+
+		[ProtoMember(3)]
+		public float Angle { get; set; }
+
+
+
+
+
+	}
+}

--- a/src/Commands/CommandBase.cs
+++ b/src/Commands/CommandBase.cs
@@ -29,7 +29,9 @@ namespace CSM.Commands
         public const byte MoneyCommandID = 102;
         public const byte BuildingCreatedCommandID = 103;
         public const byte BuildingRemovedCommandID = 104;
-        public const byte RoadCommandID = 110;
+		public const byte BuildingRelocatedCommandID = 105;
+
+		public const byte RoadCommandID = 110;
 
         #endregion Commands
 

--- a/src/Extensions/BuildingExtension.cs
+++ b/src/Extensions/BuildingExtension.cs
@@ -2,87 +2,152 @@
 using CSM.Helpers;
 using CSM.Networking;
 using ICities;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace CSM.Extensions
 {
-    public class BuildingExtension : BuildingExtensionBase
-    {
-        public static Vector3 LastPosition { get; set; }
+	public class BuildingExtension : BuildingExtensionBase
+	{
+		public static Vector3 LastPosition { get; set; }
 
-        public override void OnCreated(IBuilding building)
-        {
-            if (!ProtoBuf.Meta.RuntimeTypeModel.Default.IsDefined(typeof(Vector3)))
-            {
-                ProtoBuf.Meta.RuntimeTypeModel.Default[typeof(Vector3)].SetSurrogate(typeof(Vector3Surrogate));
-            }
-        }
+		/// <summary>
+		///     To find a buildings ID we use the position of the building, However when the building is relocated that is no longer possible
+		///     this dictionary registre the position of a building when it is created, making it posible to send the old location to the Server/Client.
+		/// </summary>
 
-        public override void OnBuildingCreated(ushort id)
-        {
-            base.OnBuildingCreated(id);
-            var Instance = BuildingManager.instance;
-            var position = Instance.m_buildings.m_buffer[id].m_position;  //the building data is stored in Instance.m_buildings.m_buffer[]
-            var angle = Instance.m_buildings.m_buffer[id].m_angle;
-            var length = Instance.m_buildings.m_buffer[id].Length;
-            var infoindex = Instance.m_buildings.m_buffer[id].m_infoIndex; //by sending the infoindex, the reciever can generate Building_info from the prefap
+		Dictionary<uint, Vector3> OldPosition = new Dictionary<uint, Vector3>();
 
-            if (LastPosition != position)
-            {
-                switch (MultiplayerManager.Instance.CurrentRole)
-                {
-                    case MultiplayerRole.Server:
-                        MultiplayerManager.Instance.CurrentServer.SendToClients(CommandBase.BuildingCreatedCommandID, new BuildingCreatedCommand
-                        {
-                            BuildingID = id,
-                            Position = position,
-                            Infoindex = infoindex,
-                            Angle = angle,
-                            Length = length,
-                        });
-                        break;
+		public override void OnCreated(IBuilding building)
+		{
+			if (!ProtoBuf.Meta.RuntimeTypeModel.Default.IsDefined(typeof(Vector3)))
+			{
+				ProtoBuf.Meta.RuntimeTypeModel.Default[typeof(Vector3)].SetSurrogate(typeof(Vector3Surrogate));
+			}
 
-                    case MultiplayerRole.Client:
-                        MultiplayerManager.Instance.CurrentClient.SendToServer(CommandBase.BuildingCreatedCommandID, new BuildingCreatedCommand
-                        {
-                            BuildingID = id,
-                            Position = position,
-                            Infoindex = infoindex,
-                            Angle = angle,
-                            Length = length,
-                        });
-                        break;
-                }
-            }
-            LastPosition = position;
-        }
 
-        public override void OnBuildingReleased(ushort id)
-        {
-            base.OnBuildingReleased(id);
-            var position = BuildingManager.instance.m_buildings.m_buffer[id].m_position; //Sending the position of the deleted building is nessesary to calculate the index in M_buildinggrid[index] and get the BuildingID
+			/// <summary>
+			///    Since the dictionary is lost when the program is terminated, it has to be recreated at startup to ensure that the relocation function doesn't break when loading a saved game
+			///    This for-Loop runs through the buildinggrid to extract the location of all buildings on startup and add them to dictionary.  
+			///  </summary>
 
-            switch (MultiplayerManager.Instance.CurrentRole)
-            {
-                case MultiplayerRole.Server:
-                    MultiplayerManager.Instance.CurrentServer.SendToClients(CommandBase.BuildingRemovedCommandID, new BuildingRemovedCommand
-                    {
-                        Position = position,
-                    });
-                    break;
+			for (uint i = 0; i < BuildingManager.instance.m_buildingGrid.Length; i++)
+			{
+				if (BuildingManager.instance.m_buildingGrid[i] != 0)
+				{
+					var BuildingID = BuildingManager.instance.m_buildingGrid[i];
+					OldPosition.Add(BuildingID, BuildingManager.instance.m_buildings.m_buffer[BuildingID].m_position);
+				}
+			}
+		}
 
-                case MultiplayerRole.Client:
-                    MultiplayerManager.Instance.CurrentClient.SendToServer(CommandBase.BuildingRemovedCommandID, new BuildingRemovedCommand
-                    {
-                        Position = position,
-                    });
-                    break;
-            }
-        }
+		public override void OnBuildingCreated(ushort id)
+		{
+			base.OnBuildingCreated(id);
+			var Instance = BuildingManager.instance;
+			var position = Instance.m_buildings.m_buffer[id].m_position;  //the building data is stored in Instance.m_buildings.m_buffer[]
+			var angle = Instance.m_buildings.m_buffer[id].m_angle;
+			var length = Instance.m_buildings.m_buffer[id].Length;
+			var infoindex = Instance.m_buildings.m_buffer[id].m_infoIndex; //by sending the infoindex, the reciever can generate Building_info from the prefap
 
-        public override void OnBuildingRelocated(ushort id)
-        {
-            base.OnBuildingRelocated(id);
-        }
-    }
+
+
+
+			if (LastPosition != position)
+			{
+				switch (MultiplayerManager.Instance.CurrentRole)
+				{
+					case MultiplayerRole.Server:
+						MultiplayerManager.Instance.CurrentServer.SendToClients(CommandBase.BuildingCreatedCommandID, new BuildingCreatedCommand
+						{
+							BuildingID = id,
+							Position = position,
+							Infoindex = infoindex,
+							Angle = angle,
+							Length = length,
+						});
+						break;
+
+					case MultiplayerRole.Client:
+						MultiplayerManager.Instance.CurrentClient.SendToServer(CommandBase.BuildingCreatedCommandID, new BuildingCreatedCommand
+						{
+							BuildingID = id,
+							Position = position,
+							Infoindex = infoindex,
+							Angle = angle,
+							Length = length,
+						});
+						break;
+				}
+			}
+			OldPosition.Add(id, position); // when a building is created its position is added to the dictionary
+
+			LastPosition = position;
+		}
+
+		public override void OnBuildingReleased(ushort id)
+		{
+			base.OnBuildingReleased(id);
+			var position = BuildingManager.instance.m_buildings.m_buffer[id].m_position; //Sending the position of the deleted building is nessesary to calculate the index in M_buildinggrid[index] and get the BuildingID
+
+			switch (MultiplayerManager.Instance.CurrentRole)
+			{
+				case MultiplayerRole.Server:
+					MultiplayerManager.Instance.CurrentServer.SendToClients(CommandBase.BuildingRemovedCommandID, new BuildingRemovedCommand
+					{
+						Position = position,
+					});
+					break;
+
+				case MultiplayerRole.Client:
+					MultiplayerManager.Instance.CurrentClient.SendToServer(CommandBase.BuildingRemovedCommandID, new BuildingRemovedCommand
+					{
+						Position = position,
+					});
+					break;
+			}
+			OldPosition.Remove(id); // when a building is released its position is removed to the dictionary
+		}
+
+		public override void OnBuildingRelocated(ushort id)
+		{
+			base.OnBuildingRelocated(id);
+
+			/// <summary>
+			/// Sends a buildings old position (for identification purpose), its new position and it new angle
+			/// </summary>
+
+			var oldPosition = OldPosition[id];
+			var newPosition = BuildingManager.instance.m_buildings.m_buffer[id].m_position;
+			var angle = BuildingManager.instance.m_buildings.m_buffer[id].m_angle;
+
+			switch (MultiplayerManager.Instance.CurrentRole)
+			{
+				case MultiplayerRole.Server:
+					MultiplayerManager.Instance.CurrentServer.SendToClients(CommandBase.BuildingRelocatedCommandID, new BuildingRelocationCommand
+					{
+						OldPosition = oldPosition,
+						NewPosition = newPosition,
+						Angle = angle,
+
+					});
+					break;
+
+				case MultiplayerRole.Client:
+					MultiplayerManager.Instance.CurrentClient.SendToServer(CommandBase.BuildingRelocatedCommandID, new BuildingRelocationCommand
+					{
+						OldPosition = oldPosition,
+						NewPosition = newPosition,
+						Angle = angle,
+					});
+					break;
+			}
+
+			OldPosition.Remove(id);
+			OldPosition.Add(id, newPosition);
+
+
+
+		}
+	}
 }

--- a/src/Networking/Client.cs
+++ b/src/Networking/Client.cs
@@ -308,8 +308,8 @@ namespace CSM.Networking
 
                     case CommandBase.BuildingRemovedCommandID:
                         var BuildingRemovedPosition = CommandBase.Deserialize<BuildingRemovedCommand>(message);
-                        int num = Mathf.Clamp((int)((BuildingRemovedPosition.Position.x / 64f) + 135f), 0, 0x10d); //The buildingID is stored in the M_buildingGrid[index] which is calculated by thís arbitrary calculation using the buildings position
-                        int index = (Mathf.Clamp((int)((BuildingRemovedPosition.Position.z / 64f) + 135f), 0, 0x10d) * 270) + num;
+                        long num = Mathf.Clamp((int)((BuildingRemovedPosition.Position.x / 64f) + 135f), 0, 0x10d); //The buildingID is stored in the M_buildingGrid[index] which is calculated by thís arbitrary calculation using the buildings position
+                        long index = (Mathf.Clamp((int)((BuildingRemovedPosition.Position.z / 64f) + 135f), 0, 0x10d) * 270) + num;
                         var BuildingId = BuildingManager.instance.m_buildingGrid[index];
                         if (BuildingId != 0)
                         {
@@ -317,7 +317,16 @@ namespace CSM.Networking
                         }
                         break;
 
-                    case CommandBase.RoadCommandID:
+					case CommandBase.BuildingRelocatedCommandID:
+						var BuildingRelocationData = CommandBase.Deserialize<BuildingRelocationCommand>(message);
+						long num2 = Mathf.Clamp((int)((BuildingRelocationData.OldPosition.x / 64f) + 135f), 0, 0x10d); //The buildingID is stored in the M_buildingGrid[index] which is calculated by thís arbitrary calculation using the buildings position
+						long index2 = (Mathf.Clamp((int)((BuildingRelocationData.OldPosition.z / 64f) + 135f), 0, 0x10d) * 270) + num2;
+						ushort BuildingId2 = BuildingManager.instance.m_buildingGrid[index2];
+						Singleton<BuildingManager>.instance.RelocateBuilding(BuildingId2, BuildingRelocationData.NewPosition, BuildingRelocationData.Angle);
+						break;
+
+
+					case CommandBase.RoadCommandID:
                         UnityEngine.Debug.Log("Road Command Recived");
                         var Roads = CommandBase.Deserialize<RoadCommand>(message);
                         NetInfo netinfo = PrefabCollection<NetInfo>.GetPrefab(Roads.InfoIndex);

--- a/src/Networking/Server.cs
+++ b/src/Networking/Server.cs
@@ -307,15 +307,23 @@ namespace CSM.Networking
 
                     case CommandBase.BuildingRemovedCommandID:
                         var BuildingRemovedPosition = CommandBase.Deserialize<BuildingRemovedCommand>(message);
-                        int num = Mathf.Clamp((int)((BuildingRemovedPosition.Position.x / 64f) + 135f), 0, 0x10d);  //The buildingID is stored in the M_buildingGrid[] which is calculated by thís arbitrary calculation using the buildings position
-                        int index = (Mathf.Clamp((int)((BuildingRemovedPosition.Position.z / 64f) + 135f), 0, 0x10d) * 270) + num;
+                        long num = Mathf.Clamp((int)((BuildingRemovedPosition.Position.x / 64f) + 135f), 0, 0x10d);  //The buildingID is stored in the M_buildingGrid[] which is calculated by thís arbitrary calculation using the buildings position
+                        long index = (Mathf.Clamp((int)((BuildingRemovedPosition.Position.z / 64f) + 135f), 0, 0x10d) * 270) + num;
                         var BuildingId = BuildingManager.instance.m_buildingGrid[index];
                         if (BuildingId != 0)
                         {
                             BuildingManager.instance.ReleaseBuilding(BuildingId);
                         }
                         break;
-                }
+
+					case CommandBase.BuildingRelocatedCommandID:
+						var BuildingRelocationData = CommandBase.Deserialize<BuildingRelocationCommand>(message);
+						long num2 = Mathf.Clamp((int)((BuildingRelocationData.OldPosition.x / 64f) + 135f), 0, 0x10d); //The buildingID is stored in the M_buildingGrid[index] which is calculated by thís arbitrary calculation using the buildings position
+						long index2 = (Mathf.Clamp((int)((BuildingRelocationData.OldPosition.z / 64f) + 135f), 0, 0x10d) * 270) + num2;
+						var BuildingId2 = BuildingManager.instance.m_buildingGrid[index2];
+						Singleton<BuildingManager>.instance.RelocateBuilding(BuildingId2, BuildingRelocationData.NewPosition, BuildingRelocationData.Angle);
+						break;
+				}
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This add the functionality of relocating buildings.

To get this to work it was necessary to add a local dictionary storage that contains all buildings position, to ensure that this does not break save-game functionality, the dictionary is created on startup and filled with the position of all existing buildings.

Please be aware that one time running this code i got an Message Array index out of bound exception, i have not been able to recreate this bug, so please report it if it reappears