### PR TITLE
Makes the Server side handle demand and sync Demand shown on UI.

### DIFF
--- a/src/CSM.csproj
+++ b/src/CSM.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Commands\ConnectionCloseCommand.cs" />
     <Compile Include="Commands\ConnectionRequestCommand.cs" />
     <Compile Include="Commands\ConnectionResultCommand.cs" />
+    <Compile Include="Commands\DemandDisplayedCommand.cs" />
     <Compile Include="Commands\PlayerListCommand.cs" />
     <Compile Include="Commands\MoneyCommand.cs" />
     <Compile Include="Commands\PingCommand.cs" />

--- a/src/Commands/CommandBase.cs
+++ b/src/Commands/CommandBase.cs
@@ -31,6 +31,7 @@ namespace CSM.Commands
         public const byte BuildingCreatedCommandID = 103;
         public const byte BuildingRemovedCommandID = 104;
         public const byte BuildingRelocatedCommandID = 105;
+		public const byte DemandDisplayedCommandID = 106;
 
         public const byte RoadCommandID = 110;
 

--- a/src/Commands/DemandDisplayedCommand.cs
+++ b/src/Commands/DemandDisplayedCommand.cs
@@ -1,0 +1,21 @@
+﻿using ProtoBuf;
+
+namespace CSM.Commands
+{
+	/// <summary>
+	/// This sends the demand displayed on the UI
+	/// </summary>
+	[ProtoContract]
+	public class DemandDisplayedCommand : CommandBase
+	{
+		[ProtoMember(1)]
+		public int ResidentialDemand { get; set; }
+
+		[ProtoMember(2)]
+		public int CommercialDemand { get; set; }
+
+		[ProtoMember(3)]
+		public int WorkplaceDemand { get; set; }
+
+	}
+}

--- a/src/Extensions/DemandExtension.cs
+++ b/src/Extensions/DemandExtension.cs
@@ -1,11 +1,71 @@
 ﻿using ICities;
+using CSM.Networking;
+using ColossalFramework;
+using CSM.Commands;
+
 
 namespace CSM.Extensions
 {
     /// <summary>
-    ///     This extension is used to sync building demand between client and server.
+    ///    This lets the serverside handle demand by setting the actual demand on the clients to 0, it also sync the demand shown on the UI by sending the servers UIdata to the Client.
     /// </summary>
     public class DemandExtension : DemandExtensionBase
     {
-    }
+		public override int OnCalculateCommercialDemand(int originalDemand)
+		{
+			switch (MultiplayerManager.Instance.CurrentRole)
+			{
+				case MultiplayerRole.Client:
+					{
+						Singleton<ZoneManager>.instance.m_actualCommercialDemand = 0;
+						break;
+					}
+			}
+			return base.OnCalculateCommercialDemand(originalDemand);
+		}
+
+		public override int OnCalculateResidentialDemand(int originalDemand)
+		{
+			switch (MultiplayerManager.Instance.CurrentRole)
+			{
+				case MultiplayerRole.Client:
+					{
+						Singleton<ZoneManager>.instance.m_actualResidentialDemand = 0;
+						break;
+					}
+
+				case MultiplayerRole.Server: //Sends the UI data of the different types of Demand
+					{
+						var ResidentialDemand = Singleton<ZoneManager>.instance.m_residentialDemand;
+						var CommercialDemand = Singleton<ZoneManager>.instance.m_commercialDemand;
+						var WorkplaceDemant = Singleton<ZoneManager>.instance.m_workplaceDemand;
+
+						MultiplayerManager.Instance.CurrentServer.SendToClients(CommandBase.DemandDisplayedCommandID, new DemandDisplayedCommand
+						{
+							ResidentialDemand = ResidentialDemand,
+							CommercialDemand = CommercialDemand,
+							WorkplaceDemand = WorkplaceDemant
+						});
+						break;
+					}
+			}	
+			return base.OnCalculateResidentialDemand(originalDemand);
+		}
+
+
+		public override int OnCalculateWorkplaceDemand(int originalDemand)
+		{
+			switch (MultiplayerManager.Instance.CurrentRole)
+			{
+				case MultiplayerRole.Client:
+					{
+						Singleton<ZoneManager>.instance.m_actualWorkplaceDemand = 0;
+						break;
+					}
+			}
+			return base.OnCalculateWorkplaceDemand(originalDemand);
+		}
+
+
+	}
 }

--- a/src/Networking/Client.cs
+++ b/src/Networking/Client.cs
@@ -338,7 +338,16 @@ namespace CSM.Networking
                         SimulationManager.instance.m_currentGameTime = worldInfo.CurrentGameTime;
                         SimulationManager.instance.m_currentDayTimeHour = worldInfo.CurrentDayTimeHour;
                         break;
-                }
+
+					case CommandBase.DemandDisplayedCommandID:
+						var DemandInfo = CommandBase.Deserialize<DemandDisplayedCommand>(message);
+						Singleton<ZoneManager>.instance.m_residentialDemand = DemandInfo.ResidentialDemand;
+						Singleton<ZoneManager>.instance.m_commercialDemand = DemandInfo.CommercialDemand;
+						Singleton<ZoneManager>.instance.m_workplaceDemand = DemandInfo.WorkplaceDemand;
+						break;
+
+
+				}
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This makes the Server side handle demand by setting the actual demand on the Client side to 0, it also Sync the displayed demand from the server to the client.

When syncing of Zones are introduced this should make Demand and RCI work like in the normal game.

Also, i Opted for only syncing the displayed UI demand when the Residential Demand is updated, it should not make a noticeable difference but should be less resource demanding since its only sending one command with each demand update instead of three.