### PR TITLE
Sync Creation, modification and release of districts

### DIFF
--- a/src/CSM.csproj
+++ b/src/CSM.csproj
@@ -76,6 +76,9 @@
     <Compile Include="Commands\Data\ConnectionRequestCommand.cs" />
     <Compile Include="Commands\Data\ConnectionResultCommand.cs" />
     <Compile Include="Commands\Data\DemandDisplayedCommand.cs" />
+    <Compile Include="Commands\Data\DistrictAreaModifyCommand.cs" />
+    <Compile Include="Commands\Data\DistrictCreateCommand.cs" />
+    <Compile Include="Commands\Data\DistrictReleaseCommand.cs" />
     <Compile Include="Commands\Data\FinishTransactionCommand.cs" />
     <Compile Include="Commands\Data\TreeMoveCommand.cs" />
     <Compile Include="Commands\Data\NodeCreateCommand.cs" />
@@ -98,6 +101,9 @@
     <Compile Include="Commands\Handler\BuildingRelocateHandler.cs" />
     <Compile Include="Commands\Handler\BuildingRemoveHandler.cs" />
     <Compile Include="Commands\Handler\ChatMessageHandler.cs" />
+    <Compile Include="Commands\Handler\DistrictAreaModifyHandler.cs" />
+    <Compile Include="Commands\Handler\DistrictCreateHandler.cs" />
+    <Compile Include="Commands\Handler\DistrictReleaseHandler.cs" />
     <Compile Include="Commands\Handler\FinishTransactionHandler.cs" />
     <Compile Include="Commands\Handler\MoneyHandler.cs" />
     <Compile Include="Commands\Handler\NodeCreateHandler.cs" />
@@ -132,6 +138,7 @@
     <Compile Include="Helpers\ArrayXExtension.cs" />
     <Compile Include="Helpers\ArrayHelpers.cs" />
     <Compile Include="Helpers\Tuple.cs" />
+    <Compile Include="Injections\DistrictHandler.cs" />
     <Compile Include="Injections\NodeHandler.cs" />
     <Compile Include="Injections\TreeHandler.cs" />
     <Compile Include="Injections\ZoneHandler.cs" />

--- a/src/Commands/CommandIds.cs
+++ b/src/Commands/CommandIds.cs
@@ -40,7 +40,9 @@
         public const byte TreeCreateCommand = 116;
         public const byte TreeMoveCommand = 117;
         public const byte TreeReleaseCommand = 118;
-
+        public const byte DistrictCreateCommand = 119;
+        public const byte DistrictAreaModifyCommand = 120;
+        public const byte DistrictReleaseCommand = 121;
         // 116 - 255
     }
 }

--- a/src/Commands/Data/DistrictAreaModifyCommand.cs
+++ b/src/Commands/Data/DistrictAreaModifyCommand.cs
@@ -1,0 +1,26 @@
+﻿using ProtoBuf;
+using UnityEngine;
+using static DistrictTool;
+
+namespace CSM.Commands
+{
+    [ProtoContract]
+    public class DistrictAreaModifyCommand : CommandBase
+    {
+        [ProtoMember(1)]
+        public Layer Layer { get; set; }   
+
+        [ProtoMember(2)]
+        public byte District { get; set; }
+
+        [ProtoMember(3)]
+        public float BrushRadius { get; set; }
+
+        [ProtoMember(4)]
+        public Vector3 StartPosition { get; set; }
+
+        [ProtoMember(5)]
+        public Vector3 EndPosition { get; set; }
+
+    }
+}

--- a/src/Commands/Data/DistrictCreateCommand.cs
+++ b/src/Commands/Data/DistrictCreateCommand.cs
@@ -1,0 +1,12 @@
+﻿using ProtoBuf;
+using UnityEngine;
+
+namespace CSM.Commands
+{
+    [ProtoContract]
+    public class DistrictCreateCommand : CommandBase
+    {
+        [ProtoMember(1)]
+        public byte DistrictID { get; set; }
+    }
+}

--- a/src/Commands/Data/DistrictReleaseCommand.cs
+++ b/src/Commands/Data/DistrictReleaseCommand.cs
@@ -1,0 +1,12 @@
+﻿using ProtoBuf;
+using UnityEngine;
+
+namespace CSM.Commands
+{
+    [ProtoContract]
+    public class DistrictReleaseCommand : CommandBase
+    {
+        [ProtoMember(1)]
+        public byte DistrictID { get; set; }
+    }
+}

--- a/src/Commands/Data/TreeReleaseCommand.cs
+++ b/src/Commands/Data/TreeReleaseCommand.cs
@@ -1,5 +1,4 @@
 ﻿using ProtoBuf;
-using UnityEngine;
 
 namespace CSM.Commands
 {

--- a/src/Commands/Handler/DistrictAreaModifyHandler.cs
+++ b/src/Commands/Handler/DistrictAreaModifyHandler.cs
@@ -1,0 +1,22 @@
+﻿using CSM.Injections;
+using CSM.Networking;
+
+namespace CSM.Commands.Handler
+{
+    public class DistrictAreaModifyHandler : CommandHandler<DistrictAreaModifyCommand>
+    {
+        public override byte ID => CommandIds.DistrictAreaModifyCommand;
+
+        public override void HandleOnClient(DistrictAreaModifyCommand command) => Handle(command);
+
+        public override void HandleOnServer(DistrictAreaModifyCommand command, Player player) => Handle(command);
+
+        private void Handle(DistrictAreaModifyCommand command)
+        {
+            DistrictHandler.IgnoreAreaModified.Add(command.StartPosition);
+            DistrictTool.ApplyBrush(command.Layer, command.District, command.BrushRadius, command.StartPosition, command.EndPosition);
+            DistrictHandler.IgnoreAreaModified.Remove(command.StartPosition);
+        }
+
+    }
+}

--- a/src/Commands/Handler/DistrictCreateHandler.cs
+++ b/src/Commands/Handler/DistrictCreateHandler.cs
@@ -1,0 +1,23 @@
+﻿using CSM.Injections;
+using CSM.Networking;
+
+
+namespace CSM.Commands.Handler
+{
+    public class DistrictCreateHandler : CommandHandler<DistrictCreateCommand>
+    {
+        public override byte ID => CommandIds.DistrictCreateCommand;
+
+        public override void HandleOnClient(DistrictCreateCommand command) => Handle(command);
+
+        public override void HandleOnServer(DistrictCreateCommand command, Player player) => Handle(command);
+
+        private void Handle(DistrictCreateCommand command)
+        {
+            DistrictHandler.IgnoreDistricts.Add(command.DistrictID);
+            DistrictManager.instance.CreateDistrict(out byte district);
+            DistrictHandler.IgnoreDistricts.Remove(command.DistrictID);
+            UnityEngine.Debug.Log($"district: {district}");
+        }
+    }
+}

--- a/src/Commands/Handler/DistrictReleaseHandler.cs
+++ b/src/Commands/Handler/DistrictReleaseHandler.cs
@@ -1,0 +1,22 @@
+﻿using CSM.Injections;
+using CSM.Networking;
+
+namespace CSM.Commands.Handler
+{
+    public class DistrictReleaseHandler : CommandHandler<DistrictReleaseCommand>
+    {
+        public override byte ID => CommandIds.DistrictReleaseCommand;
+
+        public override void HandleOnClient(DistrictReleaseCommand command) => Handle(command);
+
+        public override void HandleOnServer(DistrictReleaseCommand command, Player player) => Handle(command);
+
+        private void Handle(DistrictReleaseCommand command)
+        {
+            DistrictHandler.IgnoreDistricts.Add(command.DistrictID);
+            DistrictManager.instance.ReleaseDistrict(command.DistrictID);
+            DistrictHandler.IgnoreDistricts.Remove(command.DistrictID);
+        }
+
+    }
+}

--- a/src/Injections/DistrictHandler.cs
+++ b/src/Injections/DistrictHandler.cs
@@ -1,0 +1,74 @@
+﻿using ColossalFramework;
+using CSM.Commands;
+using Harmony;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+using static DistrictTool;
+
+namespace CSM.Injections
+{
+    class DistrictHandler
+    {
+        public static List<ushort> IgnoreDistricts { get; } = new List<ushort>();
+        public static List<Vector3> IgnoreAreaModified { get; } = new List<Vector3>();
+    }
+
+
+    [HarmonyPatch(typeof(DistrictManager))]
+    [HarmonyPatch("CreateDistrict")]
+    public class CreateDistrict
+    {
+        public static void Postfix(bool __result, ref byte district)
+        {
+            if (__result && !DistrictHandler.IgnoreDistricts.Contains(district))
+            {
+                Command.SendToAll(new DistrictCreateCommand
+                {
+                    DistrictID = district
+                });
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(DistrictTool))]
+    [HarmonyPatch("ApplyBrush")]
+    [HarmonyPatch(new Type[] { typeof(Layer), typeof(byte), typeof(float), typeof (Vector3), typeof(Vector3)})]
+    public class ApplyBrush
+    {
+        public static void Postfix (Layer layer, byte district, float brushRadius, Vector3 startPosition, Vector3 endPosition)
+        {
+            if (!DistrictHandler.IgnoreAreaModified.Contains(startPosition))
+            {
+                Command.SendToAll(new DistrictAreaModifyCommand
+                {
+                    Layer = layer,
+                    District = district,
+                    BrushRadius = brushRadius,
+                    StartPosition = startPosition,
+                    EndPosition = endPosition
+                });
+                
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(DistrictManager))]
+    [HarmonyPatch("ReleaseDistrict")]
+    public class ReleaseDistrict
+    {
+        public static void Postfix(byte district)
+        {
+            if (!DistrictHandler.IgnoreDistricts.Contains(district))
+            {
+                Command.SendToAll(new DistrictReleaseCommand
+                {
+                    DistrictID = district,
+                });
+            }
+        }
+    }
+
+
+}


### PR DESCRIPTION
This syncs the Creation, modification and release of districts. It does not sync policies.

Also it contains a small bug the name of the district will not show on creation , to make the name update the receiver of the district has to click on it using the district brush, the same is true for updating the names position and removing the name.