### PR TITLE
District name bugfix

### DIFF
--- a/src/Commands/Handler/DistrictAreaModifyHandler.cs
+++ b/src/Commands/Handler/DistrictAreaModifyHandler.cs
@@ -15,6 +15,7 @@ namespace CSM.Commands.Handler
         {
             DistrictHandler.IgnoreAreaModified.Add(command.StartPosition);
             DistrictTool.ApplyBrush(command.Layer, command.District, command.BrushRadius, command.StartPosition, command.EndPosition);
+            DistrictManager.instance.NamesModified();
             DistrictHandler.IgnoreAreaModified.Remove(command.StartPosition);
         }
 

--- a/src/Injections/DistrictHandler.cs
+++ b/src/Injections/DistrictHandler.cs
@@ -66,7 +66,7 @@ namespace CSM.Injections
                 {
                     DistrictID = district,
                 });
-            }
+            }            
         }
     }
 


### PR DESCRIPTION
Fixes the bug where the name of a district did not update, by calling the NameModified method, each time the ApplyBrush is called