### PR TITLE
Updated "Show/Hide Multiplayer Menu" strings

### DIFF
--- a/src/Extensions/LoadingExtension.cs
+++ b/src/Extensions/LoadingExtension.cs
@@ -30,7 +30,7 @@ namespace CSM.Extensions
             _multiplayerButton = (UIButton)uiView.AddUIComponent(typeof(UIButton));
 
             _multiplayerButton.text = "Multiplayer";
-            _multiplayerButton.width = 240;
+            _multiplayerButton.width = 150;
             _multiplayerButton.height = 40;
 
             _multiplayerButton.normalBgSprite = "ButtonMenu";

--- a/src/Extensions/LoadingExtension.cs
+++ b/src/Extensions/LoadingExtension.cs
@@ -29,7 +29,7 @@ namespace CSM.Extensions
 
             _multiplayerButton = (UIButton)uiView.AddUIComponent(typeof(UIButton));
 
-            _multiplayerButton.text = "Show Multiplayer Menu";
+            _multiplayerButton.text = "Multiplayer";
             _multiplayerButton.width = 240;
             _multiplayerButton.height = 40;
 
@@ -62,14 +62,6 @@ namespace CSM.Extensions
                 else
                 {
                     var newConnectionPanel = (ConnectionPanel)uiView.AddUIComponent(typeof(ConnectionPanel));
-                    _multiplayerButton.text = "Hide Multiplayer Menu";
-
-                    // Bind visibility changed event to update button text
-                    newConnectionPanel.eventVisibilityChanged +=
-                        (uiComponent, value) =>
-                        {
-                            _multiplayerButton.text = uiComponent.isVisible ? "Hide Multiplayer Menu" : "Show Multiplayer Menu";
-                        };
                 }
             };
         }


### PR DESCRIPTION
Basically trims the "Show/Hide" and "Menu" from the Multiplayer button. Main reason for this is that it is redundant to have a button since the user will know when a menu is opened or not. 

Another reason for this change is to assist with certain players that are playing on a lower resolution as the buttons can take a little bit more real estate.

Note: This is a very minor change and understand if you feel this is not needed. Just figured I'd help out even if it is an extremely minimal change!