### PR TITLE
Handle random ids without copying the Cities code

### DIFF
--- a/src/CSM.cs
+++ b/src/CSM.cs
@@ -1,14 +1,9 @@
-﻿using ColossalFramework;
-using ColossalFramework.UI;
-using CSM.Models;
-using CSM.Panels;
-using Harmony;
+﻿using Harmony;
 using NLog;
 using NLog.Config;
 using NLog.Targets;
 using System;
 using System.Reflection;
-using UnityEngine;
 
 namespace CSM
 {

--- a/src/CSM.csproj
+++ b/src/CSM.csproj
@@ -159,6 +159,7 @@
     <Compile Include="Helpers\ArrayXExtension.cs" />
     <Compile Include="Helpers\ArrayHelpers.cs" />
     <Compile Include="Helpers\Tuple.cs" />
+    <Compile Include="Injections\ArrayHandler.cs" />
     <Compile Include="Injections\DistrictHandler.cs" />
     <Compile Include="Injections\MainMenuHandler.cs" />
     <Compile Include="Injections\EconomyHandler.cs" />

--- a/src/Commands/Handler/DistrictAreaModifyHandler.cs
+++ b/src/Commands/Handler/DistrictAreaModifyHandler.cs
@@ -6,12 +6,13 @@ namespace CSM.Commands.Handler
     {
         public override void Handle(DistrictAreaModifyCommand command)
         {
-            DistrictHandler.IgnoreAreaModified.Add(command.StartPosition);
+            DistrictHandler.IgnoreAll = true;
+
             DistrictTool.ApplyBrush(command.Layer, command.District, command.BrushRadius, command.StartPosition, command.EndPosition);
             DistrictManager.instance.NamesModified();
             DistrictManager.instance.ParkNamesModified();
-            DistrictHandler.IgnoreAreaModified.Remove(command.StartPosition);
-        }
 
+            DistrictHandler.IgnoreAll = false;
+        }
     }
 }

--- a/src/Commands/Handler/DistrictCityPolicyHandler.cs
+++ b/src/Commands/Handler/DistrictCityPolicyHandler.cs
@@ -6,9 +6,9 @@ namespace CSM.Commands.Handler
     {
         public override void Handle(DistrictCityPolicyCommand command)
         {
-            DistrictHandler.ignoreCityPolicy = true;
+            DistrictHandler.IgnoreAll = true;
             DistrictManager.instance.SetCityPolicy(command.Policy);
-            DistrictHandler.ignoreCityPolicy = false;
+            DistrictHandler.IgnoreAll = false;
         }
     }
 }

--- a/src/Commands/Handler/DistrictCityPolicyUnsetHandler.cs
+++ b/src/Commands/Handler/DistrictCityPolicyUnsetHandler.cs
@@ -6,10 +6,9 @@ namespace CSM.Commands.Handler
     {
         public override void Handle(DistrictCityPolicyUnsetCommand command)
         {
-            DistrictHandler.ignoreCityPolicy = true;
+            DistrictHandler.IgnoreAll = true;
             DistrictManager.instance.UnsetCityPolicy(command.Policy);
-            DistrictHandler.ignoreCityPolicy = false;
+            DistrictHandler.IgnoreAll = false;
         }
-
     }
 }

--- a/src/Commands/Handler/DistrictCreateHandler.cs
+++ b/src/Commands/Handler/DistrictCreateHandler.cs
@@ -6,9 +6,9 @@ namespace CSM.Commands.Handler
     {
         public override void Handle(DistrictCreateCommand command)
         {
-            DistrictHandler.IgnoreDistricts.Add(command.DistrictID);
+            DistrictHandler.IgnoreAll = true;
             DistrictManager.instance.CreateDistrict(out byte district);
-            DistrictHandler.IgnoreDistricts.Remove(command.DistrictID);
+            DistrictHandler.IgnoreAll = false;
         }
     }
 }

--- a/src/Commands/Handler/DistrictPolicyHandler.cs
+++ b/src/Commands/Handler/DistrictPolicyHandler.cs
@@ -6,9 +6,9 @@ namespace CSM.Commands.Handler
     {
         public override void Handle(DistrictPolicyCommand command)
         {
-            DistrictHandler.IgnoreDistricts.Add(command.DistrictID);
+            DistrictHandler.IgnoreAll = true;
             DistrictManager.instance.SetDistrictPolicy(command.Policy, command.DistrictID);
-            DistrictHandler.IgnoreDistricts.Remove(command.DistrictID);
+            DistrictHandler.IgnoreAll = false;
         }
     }
 }

--- a/src/Commands/Handler/DistrictPolicyUnsetHandler.cs
+++ b/src/Commands/Handler/DistrictPolicyUnsetHandler.cs
@@ -6,10 +6,9 @@ namespace CSM.Commands.Handler
     {
         public override void Handle(DistrictPolicyUnsetCommand command)
         {
-            DistrictHandler.IgnoreDistricts.Add(command.DistrictID);
+            DistrictHandler.IgnoreAll = true;
             DistrictManager.instance.UnsetDistrictPolicy(command.Policy, command.DistrictID);
-            DistrictHandler.IgnoreDistricts.Remove(command.DistrictID);
+            DistrictHandler.IgnoreAll = false;
         }
-
     }
 }

--- a/src/Commands/Handler/DistrictReleaseHandler.cs
+++ b/src/Commands/Handler/DistrictReleaseHandler.cs
@@ -6,10 +6,9 @@ namespace CSM.Commands.Handler
     {
         public override void Handle(DistrictReleaseCommand command)
         {
-            DistrictHandler.IgnoreDistricts.Add(command.DistrictID);
+            DistrictHandler.IgnoreAll = true;
             DistrictManager.instance.ReleaseDistrict(command.DistrictID);
-            DistrictHandler.IgnoreDistricts.Remove(command.DistrictID);
+            DistrictHandler.IgnoreAll = false;
         }
-
     }
 }

--- a/src/Commands/Handler/NodeCreateHandler.cs
+++ b/src/Commands/Handler/NodeCreateHandler.cs
@@ -1,56 +1,20 @@
-﻿using ColossalFramework;
-using CSM.Helpers;
-using Harmony;
-using System.Reflection;
+﻿using CSM.Injections;
 
 namespace CSM.Commands.Handler
 {
     public class NodeCreateHandler : CommandHandler<NodeCreateCommand>
     {
-        private MethodInfo _initializeNode;
-
-        public NodeCreateHandler()
-        {
-            _initializeNode = typeof(NetManager).GetMethod("InitializeNode", AccessTools.all);
-        }
-
         public override void Handle(NodeCreateCommand command)
         {
             NetInfo info = PrefabCollection<NetInfo>.GetPrefab(command.InfoIndex);
-            ushort node = command.NodeId;
-            // Don't allow this node id to be taken (=CreateItem at the creator)
-            Singleton<NetManager>.instance.m_nodes.RemoveUnused(node);
 
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].m_position = command.Position;
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].m_flags = NetNode.Flags.Created;
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].Info = info;
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].m_buildIndex = Singleton<SimulationManager>.instance.m_currentBuildIndex;
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].m_building = 0;
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].m_lane = 0u;
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].m_nextLaneNode = 0;
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].m_nextBuildingNode = 0;
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].m_nextGridNode = 0;
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].m_laneOffset = 0;
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].m_elevation = 0;
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].m_heightOffset = 0;
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].m_problems = Notification.Problem.None;
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].m_transportLine = 0;
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].m_connectCount = 0;
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].m_maxWaitTime = 0;
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].m_coverage = 0;
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].m_tempCounter = 0;
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].m_finalCounter = 0;
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].m_targetCitizens = 0;
+            NodeHandler.IgnoreAll = true;
+            ArrayHandler.StartApplying(new ushort[] { command.NodeId }, null);
 
-            info.m_netAI.CreateNode(node, ref Singleton<NetManager>.instance.m_nodes.m_buffer[node]);
-            _initializeNode.Invoke(Singleton<NetManager>.instance, new object[] { node, Singleton<NetManager>.instance.m_nodes.m_buffer[node] });
+            NetManager.instance.CreateNode(out ushort _, ref SimulationManager.instance.m_randomizer, info, command.Position, SimulationManager.instance.m_currentBuildIndex++);
 
-            Singleton<NetManager>.instance.UpdateNode(node);
-            Singleton<NetManager>.instance.UpdateNodeColors(node);
-            Singleton<NetManager>.instance.m_nodes.m_buffer[node].UpdateBounds(node);
-            Singleton<NetManager>.instance.m_nodeCount = ((int) Singleton<NetManager>.instance.m_nodes.ItemCount()) - 1;
-
-            Singleton<SimulationManager>.instance.m_currentBuildIndex++;
+            ArrayHandler.StopApplying();
+            NodeHandler.IgnoreAll = false;
         }
     }
 }

--- a/src/Commands/Handler/NodeReleaseHandler.cs
+++ b/src/Commands/Handler/NodeReleaseHandler.cs
@@ -7,9 +7,9 @@ namespace CSM.Commands.Handler
     {
         public override void Handle(NodeReleaseCommand command)
         {
-            NodeHandler.IgnoreNodes.Add(command.NodeId);
+            NodeHandler.IgnoreAll = true;
             Singleton<NetManager>.instance.ReleaseNode(command.NodeId);
-            NodeHandler.IgnoreNodes.Remove(command.NodeId);
+            NodeHandler.IgnoreAll = false;
         }
     }
 }

--- a/src/Commands/Handler/ParkCreateHandler.cs
+++ b/src/Commands/Handler/ParkCreateHandler.cs
@@ -6,9 +6,9 @@ namespace CSM.Commands.Handler
     {
         public override void Handle(ParkCreateCommand command)
         {
-            DistrictHandler.IgnoreParks.Add(command.ParkID);
+            DistrictHandler.IgnoreAll = true;
             DistrictManager.instance.CreatePark(out byte Park, command.ParkType, command.ParkLevel);
-            DistrictHandler.IgnoreParks.Remove(command.ParkID);
+            DistrictHandler.IgnoreAll = false;
         }
     }
 }

--- a/src/Commands/Handler/ParkReleaseHandler.cs
+++ b/src/Commands/Handler/ParkReleaseHandler.cs
@@ -6,10 +6,9 @@ namespace CSM.Commands.Handler
     {
         public override void Handle(ParkReleaseCommand command)
         {
-            DistrictHandler.IgnoreParks.Add(command.ParkID);
+            DistrictHandler.IgnoreAll = true;
             DistrictManager.instance.ReleasePark(command.ParkID);
-            DistrictHandler.IgnoreParks.Remove(command.ParkID);
+            DistrictHandler.IgnoreAll = false;
         }
-
     }
 }

--- a/src/Commands/Handler/PropCreateHandler.cs
+++ b/src/Commands/Handler/PropCreateHandler.cs
@@ -1,40 +1,20 @@
-﻿using ColossalFramework;
-using CSM.Helpers;
-using Harmony;
-using System.Reflection;
+﻿using CSM.Injections;
 
 namespace CSM.Commands.Handler
 {
     public class PropCreateHandler : CommandHandler<PropCreateCommand>
     {
-        private MethodInfo _initializeProp;
-
-        public PropCreateHandler()
-        {
-            _initializeProp = typeof(PropManager).GetMethod("InitializeProp", AccessTools.all);
-        }
-
         public override void Handle(PropCreateCommand command)
         {
             PropInfo info = PrefabCollection<PropInfo>.GetPrefab(command.infoindex);
-            ushort prop = command.PropID;
-            PropManager.instance.m_props.RemoveUnused(prop);
-            PropManager.instance.m_props.m_buffer[prop].m_flags = 1;
-            PropManager.instance.m_props.m_buffer[prop].Info = info;
-            PropManager.instance.m_props.m_buffer[prop].Single = command.single;
-            PropManager.instance.m_props.m_buffer[prop].Blocked = false;
-            PropManager.instance.m_props.m_buffer[prop].Position = command.position;
-            PropManager.instance.m_props.m_buffer[prop].Angle = command.angle;
-            DistrictManager instance = Singleton<DistrictManager>.instance;
-            byte park = instance.GetPark(command.position);
-            instance.m_parks.m_buffer[park].m_propCount = (ushort) (instance.m_parks.m_buffer[park].m_propCount + 1);
-            ItemClass.Availability mode = Singleton<ToolManager>.instance.m_properties.m_mode;
-            _initializeProp.Invoke(Singleton<PropManager>.instance, new object[] { prop, Singleton<PropManager>.instance.m_props.m_buffer[prop], ((mode & ItemClass.Availability.AssetEditor) != ItemClass.Availability.None) });
-            PropManager.instance.UpdateProp(prop);
-            PropManager.instance.m_propCount = ((int) PropManager.instance.m_props.ItemCount()) - 1;
 
+            PropHandler.IgnoreAll = true;
+            ArrayHandler.StartApplying(new ushort[] { command.PropID }, null);
 
+            PropManager.instance.CreateProp(out ushort _, ref SimulationManager.instance.m_randomizer, info, command.position, command.angle, command.single);
 
+            ArrayHandler.StopApplying();
+            PropHandler.IgnoreAll = false;
         }
     }
 }

--- a/src/Commands/Handler/PropMoveHandler.cs
+++ b/src/Commands/Handler/PropMoveHandler.cs
@@ -6,9 +6,9 @@ namespace CSM.Commands.Handler
     {
         public override void Handle(PropMoveCommand command)
         {
-            PropHandler.IgnoreProp.Add(command.PropID);
+            PropHandler.IgnoreAll = true;
             PropManager.instance.MoveProp(command.PropID, command.Position);
-            PropHandler.IgnoreProp.Remove(command.PropID);
+            PropHandler.IgnoreAll = false;
         }
     }
 }

--- a/src/Commands/Handler/PropReleaseHandler.cs
+++ b/src/Commands/Handler/PropReleaseHandler.cs
@@ -6,9 +6,9 @@ namespace CSM.Commands.Handler
     {
         public override void Handle(PropReleaseCommand command)
         {
-            PropHandler.IgnoreProp.Add(command.PropID);
+            PropHandler.IgnoreAll = true;
             PropManager.instance.ReleaseProp(command.PropID);
-            PropHandler.IgnoreProp.Remove(command.PropID);
+            PropHandler.IgnoreAll = false;
         }
     }
 }

--- a/src/Commands/Handler/SegmentCreateHandler.cs
+++ b/src/Commands/Handler/SegmentCreateHandler.cs
@@ -1,89 +1,20 @@
-﻿using ColossalFramework;
-using CSM.Helpers;
-using Harmony;
-using System.Reflection;
+﻿using CSM.Injections;
 
 namespace CSM.Commands.Handler
 {
     public class SegmentCreateHandler : CommandHandler<SegmentCreateCommand>
     {
-        private MethodInfo _initializeSegment;
-
-        public SegmentCreateHandler()
-        {
-            _initializeSegment = typeof(NetManager).GetMethod("InitializeSegment", AccessTools.all);
-        }
-
         public override void Handle(SegmentCreateCommand command)
         {
             NetInfo info = PrefabCollection<NetInfo>.GetPrefab(command.InfoIndex);
-            ushort segment = command.SegmentID;
 
-            Singleton<NetManager>.instance.m_segments.RemoveUnused(segment);
+            NodeHandler.IgnoreAll = true;
+            ArrayHandler.StartApplying(new ushort[] { command.SegmentID }, null);
 
-            if (!Singleton<NetManager>.instance.m_nodes.m_buffer[command.StartNode].AddSegment(segment))
-            {
-                Singleton<NetManager>.instance.m_segments.ReleaseItem(segment);
-            }
-            if (!Singleton<NetManager>.instance.m_nodes.m_buffer[command.EndNode].AddSegment(segment))
-            {
-                Singleton<NetManager>.instance.m_nodes.m_buffer[command.StartNode].RemoveSegment(segment);
-                Singleton<NetManager>.instance.m_segments.ReleaseItem(segment);
-            }
+            NetManager.instance.CreateSegment(out ushort _, ref SimulationManager.instance.m_randomizer, info, command.StartNode, command.EndNode, command.StartDirection, command.EndDirection, SimulationManager.instance.m_currentBuildIndex++, command.ModifiedIndex, command.Invert);
 
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_flags = NetSegment.Flags.Created;
-            if (command.Invert)
-            {
-                Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_flags |= NetSegment.Flags.Invert;
-            }
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].Info = info;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_buildIndex = Singleton<SimulationManager>.instance.m_currentBuildIndex;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_modifiedIndex = command.ModifiedIndex;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_startNode = command.StartNode;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_endNode = command.EndNode;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_startDirection = command.StartDirection;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_endDirection = command.EndDirection;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_problems = Notification.Problem.None;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_blockStartLeft = 0;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_blockStartRight = 0;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_blockEndLeft = 0;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_blockEndRight = 0;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_lanes = 0u;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_path = 0u;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_trafficBuffer = 0;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_trafficDensity = 0;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_trafficLightState0 = 0;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_trafficLightState1 = 0;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_startLeftSegment = 0;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_startRightSegment = 0;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_endLeftSegment = 0;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_endRightSegment = 0;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_averageLength = 0f;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_nextGridSegment = 0;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_cornerAngleStart = 0;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_cornerAngleEnd = 0;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_fireCoverage = 0;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_wetness = 0;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_condition = 0;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_nameSeed = 0;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_noiseBuffer = 0;
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_noiseDensity = 0;
-
-            info.m_netAI.CreateSegment(segment, ref Singleton<NetManager>.instance.m_segments.m_buffer[segment]);
-            if (info.m_lanes != null)
-            {
-                Singleton<NetManager>.instance.CreateLanes(out Singleton<NetManager>.instance.m_segments.m_buffer[segment].m_lanes, ref Singleton<SimulationManager>.instance.m_randomizer, segment, info.m_lanes.Length);
-            }
-
-            _initializeSegment.Invoke(Singleton<NetManager>.instance, new object[] { segment, Singleton<NetManager>.instance.m_segments.m_buffer[segment] });
-
-            Singleton<NetManager>.instance.UpdateSegment(segment);
-            Singleton<NetManager>.instance.UpdateSegmentColors(segment);
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].UpdateBounds(segment);
-            Singleton<NetManager>.instance.m_segments.m_buffer[segment].UpdateZones(segment);
-            Singleton<NetManager>.instance.m_segmentCount = ((int) Singleton<NetManager>.instance.m_segments.ItemCount()) - 1;
-
-            Singleton<SimulationManager>.instance.m_currentBuildIndex++;
+            ArrayHandler.StopApplying();
+            NodeHandler.IgnoreAll = false;
         }
     }
 }

--- a/src/Commands/Handler/SegmentReleaseHandler.cs
+++ b/src/Commands/Handler/SegmentReleaseHandler.cs
@@ -7,9 +7,9 @@ namespace CSM.Commands.Handler
     {
         public override void Handle(SegmentReleaseCommand command)
         {
-            NodeHandler.IgnoreSegments.Add(command.SegmentId);
+            NodeHandler.IgnoreAll = true;
             Singleton<NetManager>.instance.ReleaseSegment(command.SegmentId, command.KeepNodes);
-            NodeHandler.IgnoreSegments.Remove(command.SegmentId);
+            NodeHandler.IgnoreAll = false;
         }
     }
 }

--- a/src/Commands/Handler/TreeCreateHandler.cs
+++ b/src/Commands/Handler/TreeCreateHandler.cs
@@ -1,37 +1,19 @@
-﻿using ColossalFramework;
-using CSM.Helpers;
-using Harmony;
-using System.Reflection;
+﻿using CSM.Injections;
 
 namespace CSM.Commands.Handler
 {
     public class TreeCreateHandler : CommandHandler<TreeCreateCommand>
     {
-        private MethodInfo _initializeTree;
-
-        public TreeCreateHandler()
-        {
-            _initializeTree = typeof(TreeManager).GetMethod("InitializeTree", AccessTools.all);
-        }
-
         public override void Handle(TreeCreateCommand command)
         {
             TreeInfo info = PrefabCollection<TreeInfo>.GetPrefab(command.InfoIndex);
-            uint tree = command.TreeID;
-            TreeManager.instance.m_trees.RemoveUnused(tree);
 
-            TreeManager.instance.m_trees.m_buffer[tree].m_flags = 1;
-            TreeManager.instance.m_trees.m_buffer[tree].Info = info;
-            TreeManager.instance.m_trees.m_buffer[tree].Single = command.Single;
-            TreeManager.instance.m_trees.m_buffer[tree].GrowState = 15;
-            TreeManager.instance.m_trees.m_buffer[tree].Position = command.Position;
-            DistrictManager instance = Singleton<DistrictManager>.instance;
-            byte park = instance.GetPark(command.Position);
-            instance.m_parks.m_buffer[park].m_treeCount++;
-            ItemClass.Availability mode = Singleton<ToolManager>.instance.m_properties.m_mode;
-            _initializeTree.Invoke(Singleton<TreeManager>.instance, new object[] { tree, Singleton<TreeManager>.instance.m_trees.m_buffer[tree], ((mode & ItemClass.Availability.AssetEditor) != ItemClass.Availability.None) });
-            TreeManager.instance.UpdateTree(tree);
-            TreeManager.instance.m_treeCount = ((int) TreeManager.instance.m_trees.ItemCount()) - 1;
+            TreeHandler.IgnoreAll = true;
+            ArrayHandler.StartApplying(null, new uint[] { command.TreeID });
+
+            TreeManager.instance.CreateTree(out uint _, ref SimulationManager.instance.m_randomizer, info, command.Position, command.Single);
+            ArrayHandler.StopApplying();
+            TreeHandler.IgnoreAll = false;
         }
     }
 }

--- a/src/Commands/Handler/TreeMoveHandler.cs
+++ b/src/Commands/Handler/TreeMoveHandler.cs
@@ -6,9 +6,9 @@ namespace CSM.Commands.Handler
     {
         public override void Handle(TreeMoveCommand command)
         {
-            TreeHandler.IgnoreTrees.Add(command.TreeID);
+            TreeHandler.IgnoreAll = true;
             TreeManager.instance.MoveTree(command.TreeID, command.Position);
-            TreeHandler.IgnoreTrees.Remove(command.TreeID);
+            TreeHandler.IgnoreAll = false;
         }
     }
 }

--- a/src/Commands/Handler/TreeReleaseHandler.cs
+++ b/src/Commands/Handler/TreeReleaseHandler.cs
@@ -6,9 +6,9 @@ namespace CSM.Commands.Handler
     {
         public override void Handle(TreeReleaseCommand command)
         {
-            TreeHandler.IgnoreTrees.Add(command.TreeID);
+            TreeHandler.IgnoreAll = true;
             TreeManager.instance.ReleaseTree(command.TreeID);
-            TreeHandler.IgnoreTrees.Remove(command.TreeID);
+            TreeHandler.IgnoreAll = false;
         }
     }
 }

--- a/src/Commands/Handler/ZoneUpdateHandler.cs
+++ b/src/Commands/Handler/ZoneUpdateHandler.cs
@@ -10,10 +10,10 @@ namespace CSM.Commands.Handler
             Singleton<ZoneManager>.instance.m_blocks.m_buffer[command.ZoneId].m_zone1 = command.Zone1;
             Singleton<ZoneManager>.instance.m_blocks.m_buffer[command.ZoneId].m_zone2 = command.Zone2;
 
-            ZoneHandler.IgnoreZones.Add(command.ZoneId);
+            ZoneHandler.IgnoreAll = true;
             // This Command is necessary to get the Zone to render, else it will first show when a building is build on it.
             Singleton<ZoneManager>.instance.m_blocks.m_buffer[command.ZoneId].RefreshZoning(command.ZoneId);
-            ZoneHandler.IgnoreZones.Remove(command.ZoneId);
+            ZoneHandler.IgnoreAll = false;
         }
     }
 }

--- a/src/Helpers/ArrayXExtension.cs
+++ b/src/Helpers/ArrayXExtension.cs
@@ -9,57 +9,59 @@ namespace CSM.Helpers
 {
     public static class ArrayXExtension
     {
-        public static void RemoveUnused<T>(this Array8<T> arr, byte id)
+        public static void RemoveUnused(object arr, uint id)
         {
-            ArrayXHelper<Array8<T>, byte>.RemoveUnused(arr, id, "Array8");
-        }
-
-        public static void RemoveUnused<T>(this Array16<T> arr, ushort id)
-        {
-            ArrayXHelper<Array16<T>, ushort>.RemoveUnused(arr, id, "Array16");
-        }
-
-        public static void RemoveUnused<T>(this Array32<T> arr, uint id)
-        {
-            ArrayXHelper<Array32<T>, uint>.RemoveUnused(arr, id, "Array32");
-        }
-
-        private static class ArrayXHelper<A, N> where N : IConvertible
-        {
-            public static void RemoveUnused(A arr, N id, string type)
+            if (arr.GetType().Name.StartsWith("Array8"))
             {
-                N[] unusedItems = (N[]) arr.GetType().GetField("m_unusedItems", AccessTools.all).GetValue(arr);
-                FieldInfo unusedCountField = arr.GetType().GetField("m_unusedCount", AccessTools.all);
-                uint unusedCount = (uint) unusedCountField.GetValue(arr);
+                RemoveUnused(arr, (byte) id, "Array8");
+            }
+            else if (arr.GetType().Name.StartsWith("Array16"))
+            {
+                RemoveUnused(arr, (ushort) id, "Array16");
+            }
+            else if (arr.GetType().Name.StartsWith("Array32"))
+            {
+                RemoveUnused(arr, id, "Array32");
+            }
+            else
+            {
+                LogManager.GetCurrentClassLogger().Error($"ArrayXExtension: {arr.GetType()} is not a supported type!");
+            }
+        }
 
-                uint expectedPos = Convert.ToUInt32(id) - 1;
-                // Special case, when array was modified (search for the id)
-                if (expectedPos >= unusedCount || !EqualityComparer<N>.Default.Equals(unusedItems[expectedPos], id))
+        private static void RemoveUnused<N>(object arr, N id, string type) where N: IConvertible
+        {
+            N[] unusedItems = (N[]) arr.GetType().GetField("m_unusedItems", AccessTools.all).GetValue(arr);
+            FieldInfo unusedCountField = arr.GetType().GetField("m_unusedCount", AccessTools.all);
+            uint unusedCount = (uint) unusedCountField.GetValue(arr);
+
+            uint expectedPos = Convert.ToUInt32(id) - 1;
+            // Special case, when array was modified (search for the id)
+            if (expectedPos >= unusedCount || !EqualityComparer<N>.Default.Equals(unusedItems[expectedPos], id))
+            {
+                bool found = false;
+                for (uint num = 0; num < unusedCount; num++)
                 {
-                    bool found = false;
-                    for (uint num = 0; num < unusedCount; num++)
+                    if (EqualityComparer<N>.Default.Equals(unusedItems[num], id))
                     {
-                        if (EqualityComparer<N>.Default.Equals(unusedItems[num], id))
-                        {
-                            expectedPos = num;
-                            found = true;
-                            break;
-                        }
-                    }
-
-                    if (!found)
-                    {
-                        // The arrays are no longer in sync
-                        LogManager.GetCurrentClassLogger().Error($"{type}: Received id {id} already in use. Please restart the multiplayer session!");
-                        ChatLogPanel.PrintGameMessage(ChatLogPanel.MessageType.Error, "ID collision. Please restart the multiplayer session.");
-                        return;
+                        expectedPos = num;
+                        found = true;
+                        break;
                     }
                 }
 
-                unusedItems[expectedPos] = unusedItems[--unusedCount];
-
-                unusedCountField.SetValue(arr, unusedCount);
+                if (!found)
+                {
+                    // The arrays are no longer in sync
+                    LogManager.GetCurrentClassLogger().Error($"{type}: Received id {id} already in use. Please restart the multiplayer session!");
+                    ChatLogPanel.PrintGameMessage(ChatLogPanel.MessageType.Error, "ID collision. Please restart the multiplayer session.");
+                    return;
+                }
             }
+
+            unusedItems[expectedPos] = unusedItems[--unusedCount];
+
+            unusedCountField.SetValue(arr, unusedCount);
         }
     }
 }

--- a/src/Injections/ArrayHandler.cs
+++ b/src/Injections/ArrayHandler.cs
@@ -1,0 +1,280 @@
+﻿using ColossalFramework.Math;
+using CSM.Helpers;
+using Harmony;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace CSM.Injections
+{
+    public class ArrayHandler
+    {
+        private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+
+        // All the types for Array16<T> and Array32<T> we currently need to track
+        // TODO: Implement building sync using this method
+        private static readonly Type[] _array16Types = new Type[] { /*typeof(Building), */typeof(NetNode), typeof(NetSegment), typeof(PropInstance) };
+        private static readonly Type[] _array32Types = new Type[] { typeof(TreeInstance) };
+
+        private static readonly List<ushort> _array16Collected = new List<ushort>();
+        private static readonly List<uint> _array32Collected = new List<uint>();
+
+        private static int _list16Pointer, _list32Pointer;
+
+        private static bool _collecting = false;
+        private static bool _applying = false;
+
+        public static ushort[] Collected16
+        {
+            get { return _array16Collected.ToArray(); }
+        }
+
+        public static uint[] Collected32
+        {
+            get { return _array32Collected.ToArray(); }
+        }
+
+        /// <summary>
+        /// Start collecting ids from id reservations.
+        /// </summary>
+        public static void StartCollecting()
+        {
+            if (_collecting)
+            {
+                _logger.Warn("ArrayHandler: Collecting already in progress! Ignoring.");
+                return;
+            }
+
+            if (_applying)
+            {
+                _logger.Warn("Arrayhandler: Started collecting while applying! Ignoring.");
+                return;
+            }
+
+            _collecting = true;
+            _array16Collected.Clear();
+            _array32Collected.Clear();
+        }
+
+        /// <summary>
+        /// Stop collecting ids. The result can be found in Collected16 and Collected32 properties.
+        /// </summary>
+        public static void StopCollecting()
+        {
+            _collecting = false;
+        }
+
+        /// <summary>
+        /// Start to intercept id reservations and apply the given ids.
+        /// </summary>
+        /// <param name="array16Ids">Ids to apply to Array16<> calls (can be null)</param>
+        /// <param name="array32Ids">Ids to apply to Array32<> calls (can be null)</param>
+        public static void StartApplying(ushort[] array16Ids, uint[] array32Ids)
+        {
+            if (_collecting)
+            {
+                _logger.Warn("ArrayHandler: Started applying while collecting! Ignoring.");
+                return;
+            }
+
+            if (_applying)
+            {
+                _logger.Warn("ArrayHandler: Applying already in progress! Ignoring.");
+                return;
+            }
+
+            _applying = true;
+
+            _array16Collected.Clear();
+            if (array16Ids != null)
+            {
+                _array16Collected.AddRange(array16Ids);
+            }
+
+            _array32Collected.Clear();
+            if (array32Ids != null)
+            {
+                _array32Collected.AddRange(array32Ids);
+            }
+
+            _list16Pointer = 0;
+            _list32Pointer = 0;
+        }
+
+        /// <summary>
+        /// Stop intercepting id reservations, will print a warning if not all ids were applied.
+        /// </summary>
+        public static void StopApplying()
+        {
+            _applying = false;
+            if (_list16Pointer != _array16Collected.Count || _list32Pointer != _array32Collected.Count)
+            {
+                _logger.Warn("ArrayHandler: Not all collected array elements have been applied!");
+            }
+        }
+
+        [HarmonyPatch]
+        public class CreateItemRand16
+        {
+            public static bool Prefix(ref ushort item, ref Randomizer r, object __instance, ref bool __result)
+            {
+                if (_applying)
+                {
+                    CreateItem16.Prefix(ref item, __instance, ref __result);
+                    
+                    // Skip this randomizer value
+                    r.Int32(1);
+
+                    // Don't execute original method
+                    return false;
+                }
+                return true;
+            }
+
+            public static void Postfix(ref ushort item)
+            {
+                if (_collecting)
+                {
+                    _array16Collected.Add(item);
+                }
+            }
+
+            public static IEnumerable<MethodBase> TargetMethods()
+            {
+                foreach (Type t in _array16Types)
+                {
+                    Type arr = typeof(Array16<>).MakeGenericType(t);
+                    yield return arr.GetMethod("CreateItem", new Type[] { typeof(ushort).MakeByRefType(), typeof(Randomizer).MakeByRefType() });
+                }
+            }
+        }
+        
+        [HarmonyPatch]
+        public class CreateItem16
+        {
+            public static bool Prefix(ref ushort item, object __instance, ref bool __result)
+            {
+                if (_applying)
+                {
+                    if (_list16Pointer == _array16Collected.Count)
+                    {
+                        _logger.Warn("ArrayHandler: Applying more items than collected!");
+                        return true;
+                    }
+
+                    item = _array16Collected[_list16Pointer];
+                    _list16Pointer++;
+
+                    ArrayXExtension.RemoveUnused(__instance, item);
+
+                    // Return true, id reservation was successful
+                    __result = true;
+
+                    // Don't execute original method
+                    return false;
+                }
+
+                return true;
+            }
+
+            public static void Postfix(ref ushort item)
+            {
+                if (_collecting)
+                {
+                    _array16Collected.Add(item);
+                }
+            }
+
+            public static IEnumerable<MethodBase> TargetMethods()
+            {
+                foreach (Type t in _array16Types)
+                {
+                    Type arr = typeof(Array16<>).MakeGenericType(t);
+                    yield return arr.GetMethod("CreateItem", new Type[] { typeof(ushort).MakeByRefType() });
+                }
+            }
+        }
+        
+        [HarmonyPatch]
+        public class CreateItemRand32
+        {
+            public static bool Prefix(ref uint item, ref Randomizer r, object __instance, ref bool __result)
+            {
+                if (_applying)
+                {
+                    CreateItem32.Prefix(ref item, __instance, ref __result);
+
+                    // Skip this randomizer value
+                    r.Int32(1);
+
+                    // Don't execute original method
+                    return false;
+                }
+                return true;
+            }
+
+            public static void Postfix(ref uint item)
+            {
+                if (_collecting)
+                {
+                    _array32Collected.Add(item);
+                }
+            }
+
+            public static IEnumerable<MethodBase> TargetMethods()
+            {
+                foreach (Type t in _array32Types)
+                {
+                    Type arr = typeof(Array32<>).MakeGenericType(t);
+                    yield return arr.GetMethod("CreateItem", new Type[] { typeof(uint).MakeByRefType(), typeof(Randomizer).MakeByRefType() });
+                }
+            }
+        }
+
+        [HarmonyPatch]
+        public class CreateItem32
+        {
+            public static bool Prefix(ref uint item, object __instance, ref bool __result)
+            {
+                if (_applying)
+                {
+                    if (_list32Pointer == _array32Collected.Count)
+                    {
+                        _logger.Warn("ArrayHandler: Applying more items than collected!");
+                        return true;
+                    }
+
+                    item = _array32Collected[_list32Pointer];
+                    _list32Pointer++;
+
+                    ArrayXExtension.RemoveUnused(__instance, item);
+
+                    // Return true, id reservation was successful
+                    __result = true;
+
+                    // Don't execute original method
+                    return false;
+                }
+
+                return true;
+            }
+
+            public static void Postfix(ref uint item)
+            {
+                if (_collecting)
+                {
+                    _array32Collected.Add(item);
+                }
+            }
+
+            public static IEnumerable<MethodBase> TargetMethods()
+            {
+                foreach (Type t in _array32Types)
+                {
+                    Type arr = typeof(Array32<>).MakeGenericType(t);
+                    yield return arr.GetMethod("CreateItem", new Type[] { typeof(uint).MakeByRefType() });
+                }
+            }
+        }
+    }
+}

--- a/src/Injections/ZoneHandler.cs
+++ b/src/Injections/ZoneHandler.cs
@@ -1,12 +1,11 @@
 ﻿using CSM.Commands;
 using Harmony;
-using System.Collections.Generic;
 
 namespace CSM.Injections
 {
     public class ZoneHandler
     {
-        public static List<ushort> IgnoreZones { get; } = new List<ushort>();
+        public static bool IgnoreAll { get; set; } = false;
     }
     
     /*
@@ -28,10 +27,8 @@ namespace CSM.Injections
         /// <param name="___m_zone2">Zone storage attribute 2</param>
         public static void Postfix(ushort blockID, ulong ___m_zone1, ulong ___m_zone2)
         {
-            if (ZoneHandler.IgnoreZones.Contains(blockID))
-            {
+            if (ZoneHandler.IgnoreAll)
                 return;
-            }
 
             Command.SendToAll(new ZoneUpdateCommand
             {


### PR DESCRIPTION
This is the first of my preparations for the transport line synchronization.

I added the `ArrayHandler` class to support synchronization of randomly generated ids:
- Allows to "collect" generated ids by intercepting all calls to `Array16<>.CreateItem(...)` and `Array32<>`
- They can be send over as an array to the other players
- Allows to apply generated ids again inside these methods (Returns an item from the array instead of calculating it randomly by overwriting the `CreateItem` methods)

I implemented this method already in all use cases other than Buildings (is a bit more complicated) and Terrain (which still requires more work, my next commit will include "tool simulation" making it easier to work with tools, since they require private fields to be synced).

Please test if everything still works. :)