### PR TITLE
Update EconomyExtension.cs

### DIFF
--- a/src/Extensions/EconomyExtension.cs
+++ b/src/Extensions/EconomyExtension.cs
@@ -25,8 +25,8 @@ namespace CSM.Extensions
         public static int[] _serviceBudgetNight;
         public static int[] _serviceBudgetDay;
         public static int[] _LastTaxrate = new int[120];
-        public static int[] _LastserviceBudgetNight = new int[30];
-        public static int[] _LastserviceBudgetDay = new int[30];
+        public static int[] _LastserviceBudgetNight = new int[35];
+        public static int[] _LastserviceBudgetDay = new int[35];
 
         public override void OnCreated(IEconomy economy)
         {


### PR DESCRIPTION
Fixed array error due to update:

[System.ArgumentException: Destination array was not long enough. Check destIndex and length, and the array's lower bounds.]