### PR TITLE
Sync initial road names, road priority setting, stop signs and traffic lights 

### DIFF
--- a/src/CSM.csproj
+++ b/src/CSM.csproj
@@ -95,6 +95,9 @@
     <Compile Include="Commands\Data\PropMoveCommand.cs" />
     <Compile Include="Commands\Data\PropReleaseCommand.cs" />
     <Compile Include="Commands\Data\ParkReleaseCommand.cs" />
+    <Compile Include="Commands\Data\RoadSetPriorityCommand.cs" />
+    <Compile Include="Commands\Data\RoadSettingsCommand.cs" />
+    <Compile Include="Commands\Data\SegmentSeedUpdateCommand.cs" />
     <Compile Include="Commands\Data\TerrainModificationCommand.cs" />
     <Compile Include="Commands\Data\TreeMoveCommand.cs" />
     <Compile Include="Commands\Data\NodeCreateCommand.cs" />
@@ -142,7 +145,10 @@
     <Compile Include="Commands\Handler\ConnectionResultHandler.cs" />
     <Compile Include="Commands\Handler\DemandDisplayedHandler.cs" />
     <Compile Include="Commands\Handler\PauseHandler.cs" />
+    <Compile Include="Commands\Handler\RoadSetPriorityHandler.cs" />
+    <Compile Include="Commands\Handler\RoadSettingsHandler.cs" />
     <Compile Include="Commands\Handler\SegmentReleaseHandler.cs" />
+    <Compile Include="Commands\Handler\SegmentSeedUpdateHandler.cs" />
     <Compile Include="Commands\Handler\SpeedHandler.cs" />
     <Compile Include="Commands\Handler\TaxRateChangeHandler.cs" />
     <Compile Include="Commands\Handler\TerrainModificationHandler.cs" />
@@ -171,6 +177,7 @@
     <Compile Include="Injections\NameHandler.cs" />
     <Compile Include="Injections\NetHandler.cs" />
     <Compile Include="Injections\PropHandler.cs" />
+    <Compile Include="Injections\RoadHandler.cs" />
     <Compile Include="Injections\TerrainHandler.cs" />
     <Compile Include="Injections\TreeHandler.cs" />
     <Compile Include="Injections\ZoneHandler.cs" />

--- a/src/Commands/Data/RoadSetPriorityCommand.cs
+++ b/src/Commands/Data/RoadSetPriorityCommand.cs
@@ -1,0 +1,14 @@
+﻿using ProtoBuf;
+
+namespace CSM.Commands
+{
+    [ProtoContract]
+    public class RoadSetPriorityCommand : CommandBase
+    {
+        [ProtoMember(1)]
+        public ushort SegmentId { get; set; }
+
+        [ProtoMember(2)]
+        public bool Priority { get; set; }
+    }
+}

--- a/src/Commands/Data/RoadSettingsCommand.cs
+++ b/src/Commands/Data/RoadSettingsCommand.cs
@@ -1,0 +1,14 @@
+﻿using ProtoBuf;
+
+namespace CSM.Commands
+{
+    [ProtoContract]
+    public class RoadSettingsCommand : CommandBase
+    {
+        [ProtoMember(1)]
+        public ushort NodeID { get; set; }
+        
+        [ProtoMember(2)]
+        public int Index { get; set; }
+    }
+}

--- a/src/Commands/Data/SegmentSeedUpdateCommand.cs
+++ b/src/Commands/Data/SegmentSeedUpdateCommand.cs
@@ -1,0 +1,14 @@
+﻿using ProtoBuf;
+
+namespace CSM.Commands
+{
+    [ProtoContract]
+    public class SegmentSeedUpdateCommand : CommandBase
+    {
+        [ProtoMember(1)]
+        public ushort SegmentId { get; set; }
+        
+        [ProtoMember(2)]
+        public ushort NameSeed { get; set; }
+    }
+}

--- a/src/Commands/Handler/RoadSetPriorityHandler.cs
+++ b/src/Commands/Handler/RoadSetPriorityHandler.cs
@@ -1,0 +1,14 @@
+﻿using CSM.Injections;
+
+namespace CSM.Commands.Handler
+{
+    public class RoadSetPriorityHandler : CommandHandler<RoadSetPriorityCommand>
+    {
+        public override void Handle(RoadSetPriorityCommand command)
+        {
+            RoadHandler.IgnoreAll = true;
+            NetManager.instance.SetPriorityRoad(command.SegmentId, command.Priority).MoveNext();
+            RoadHandler.IgnoreAll = false;
+        }
+    }
+}

--- a/src/Commands/Handler/RoadSettingsHandler.cs
+++ b/src/Commands/Handler/RoadSettingsHandler.cs
@@ -1,0 +1,29 @@
+﻿using CSM.Common;
+using CSM.Injections;
+
+namespace CSM.Commands.Handler
+{
+    public class RoadSettingsHandler : CommandHandler<RoadSettingsCommand>
+    {
+        public override void Handle(RoadSettingsCommand command)
+        {
+            RoadHandler.IgnoreAll = true;
+            
+            // Simulate traffic routes mode (otherwise the flags would not change)
+            InfoManager.InfoMode oldMode = InfoManager.instance.CurrentMode; 
+            ReflectionHelper.SetAttr(InfoManager.instance, "m_actualMode", InfoManager.InfoMode.TrafficRoutes);
+            InfoManager.SubInfoMode oldSubMode = InfoManager.instance.CurrentSubMode;
+            ReflectionHelper.SetAttr(InfoManager.instance, "m_actualSubMode", InfoManager.SubInfoMode.WaterPower);
+
+            // Apply node button click
+            NetNode[] nodes= NetManager.instance.m_nodes.m_buffer;
+            nodes[command.NodeID].Info.m_netAI.ClickNodeButton(command.NodeID, ref nodes[command.NodeID], command.Index);
+            
+            // Reset info manager mode
+            ReflectionHelper.SetAttr(InfoManager.instance, "m_actualMode", oldMode);
+            ReflectionHelper.SetAttr(InfoManager.instance, "m_actualSubMode", oldSubMode);
+
+            RoadHandler.IgnoreAll = false;
+        }
+    }
+}

--- a/src/Commands/Handler/SegmentSeedUpdateHandler.cs
+++ b/src/Commands/Handler/SegmentSeedUpdateHandler.cs
@@ -1,0 +1,13 @@
+﻿
+namespace CSM.Commands.Handler
+{
+    public class SegmentSeedUpdateHandler : CommandHandler<SegmentSeedUpdateCommand>
+    {
+        public override void Handle(SegmentSeedUpdateCommand command)
+        {
+            NetManager.instance.m_segments.m_buffer[command.SegmentId].m_nameSeed = command.NameSeed;
+            // Update name (+ make sure that we don't overwrite custom set names)
+            NetManager.instance.SetSegmentNameImpl(command.SegmentId, NetManager.instance.GetSegmentName(command.SegmentId));
+        }
+    }
+}

--- a/src/Injections/NameHandler.cs
+++ b/src/Injections/NameHandler.cs
@@ -1,5 +1,6 @@
 ﻿using CSM.Commands;
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using CSM.Commands.Handler;
 using CSM.Common;
@@ -7,12 +8,6 @@ using HarmonyLib;
 
 namespace CSM.Injections
 {
-    /*
-     * TODO: Initially sync road name seeds
-     * The seed is set after CreateSegment is called (in NetTool)
-     * To solve this, we can either sync all NetTool calls instead of the NetManager
-     * or send another command at the end of the tick after a segment has been created
-     */
     public static class NameHandler
     {
         public static bool IgnoreAll { get; set; } = false;
@@ -25,18 +20,42 @@ namespace CSM.Injections
             return ReflectionHelper.GetAttr<bool>(instance, "$current");
         }
 
-        public static void CheckCounter(object instance, ref bool state)
+        public static void CheckCounter(object instance, out bool state)
         {
             int counter = ReflectionHelper.GetAttr<int>(instance, "$PC");
             state = counter == 0;
         }
     }
+
+    [HarmonyPatch(typeof(NetSegment))]
+    [HarmonyPatch("UpdateNameSeed")]
+    public class UpdateSegmentSeed
+    {
+        public static void Prefix(out ushort __state, ushort ___m_nameSeed)
+        {
+            __state = ___m_nameSeed; // Seed before method
+        }
+        
+        public static void Postfix(ref ushort __state, ushort ___m_nameSeed, ushort segmentID)
+        {
+            // Check if seed was changed
+            if (__state != ___m_nameSeed)
+            {
+                Command.SendToAll(new SegmentSeedUpdateCommand()
+                {
+                    SegmentId = segmentID,
+                    NameSeed = ___m_nameSeed
+                });
+            }
+        }
+    }
+    
     [HarmonyPatch]
     public class SetBuildingName
     {
-        public static void Prefix(object __instance, ref bool __state)
+        public static void Prefix(object __instance, out bool __state)
         {
-            NameHandler.CheckCounter(__instance, ref __state);
+            NameHandler.CheckCounter(__instance, out __state);
         }
         
         public static void Postfix(ushort ___building, string ___name, ref bool __state, object __instance)
@@ -61,9 +80,9 @@ namespace CSM.Injections
     [HarmonyPatch]
     public class SetCitizenName
     {
-        public static void Prefix(object __instance, ref bool __state)
+        public static void Prefix(object __instance, out bool __state)
         {
-            NameHandler.CheckCounter(__instance, ref __state);
+            NameHandler.CheckCounter(__instance, out __state);
         }
         
         public static void Postfix(uint ___citizenID, string ___name, ref bool __state, object __instance)
@@ -88,9 +107,9 @@ namespace CSM.Injections
     [HarmonyPatch]
     public class SetInstanceName
     {
-        public static void Prefix(object __instance, ref bool __state)
+        public static void Prefix(object __instance, out bool __state)
         {
-            NameHandler.CheckCounter(__instance, ref __state);
+            NameHandler.CheckCounter(__instance, out __state);
         }
         
         public static void Postfix(ushort ___instanceID, string ___name, ref bool __state, object __instance)
@@ -115,9 +134,9 @@ namespace CSM.Injections
     [HarmonyPatch]
     public class SetDisasterName
     {
-        public static void Prefix(object __instance, ref bool __state)
+        public static void Prefix(object __instance, out bool __state)
         {
-            NameHandler.CheckCounter(__instance, ref __state);
+            NameHandler.CheckCounter(__instance, out __state);
         }
         
         public static void Postfix(ushort ___disasterID, string ___name, ref bool __state, object __instance)
@@ -142,9 +161,9 @@ namespace CSM.Injections
     [HarmonyPatch]
     public class SetDistrictName
     {
-        public static void Prefix(object __instance, ref bool __state)
+        public static void Prefix(object __instance, out bool __state)
         {
-            NameHandler.CheckCounter(__instance, ref __state);
+            NameHandler.CheckCounter(__instance, out __state);
         }
         
         public static void Postfix(int ___district, string ___name, ref bool __state, object __instance)
@@ -169,9 +188,9 @@ namespace CSM.Injections
     [HarmonyPatch]
     public class SetParkName
     {
-        public static void Prefix(object __instance, ref bool __state)
+        public static void Prefix(object __instance, out bool __state)
         {
-            NameHandler.CheckCounter(__instance, ref __state);
+            NameHandler.CheckCounter(__instance, out __state);
         }
         
         public static void Postfix(int ___park, string ___name, ref bool __state, object __instance)
@@ -214,33 +233,39 @@ namespace CSM.Injections
         }
     }
     
-    [HarmonyPatch(typeof(NetManager))]
-    [HarmonyPatch("SetSegmentNameImpl")]
+    [HarmonyPatch]
     public class SetSegmentName
     {
-        public static void Postfix(ushort segmentID, string name, bool __result)
+        public static void Prefix(object __instance, out bool __state)
         {
-            if (NameHandler.IgnoreAll)
-                return;
-
-            if (!__result)
+            NameHandler.CheckCounter(__instance, out __state);
+        }
+        
+        public static void Postfix(IEnumerator<bool> __instance, ref bool __state, ushort ___segmentID, string ___name)
+        {
+            if (!NameHandler.CanRun(__instance, __state))
                 return;
 
             Command.SendToAll(new ChangeNameCommand
             {
                 Type = InstanceType.NetSegment,
-                Id = segmentID,
-                Name = name
+                Id = ___segmentID,
+                Name = ___name
             });
+        }
+        
+        public static MethodBase TargetMethod()
+        {
+            return ReflectionHelper.GetIteratorTargetMethod(typeof(NetManager), "<SetSegmentName>c__Iterator2", out Type _);
         }
     }
     
     [HarmonyPatch]
     public class SetLineName
     {
-        public static void Prefix(object __instance, ref bool __state)
+        public static void Prefix(object __instance, out bool __state)
         {
-            NameHandler.CheckCounter(__instance, ref __state);
+            NameHandler.CheckCounter(__instance, out __state);
         }
         
         public static void Postfix(ushort ___lineID, string ___name, ref bool __state, object __instance)
@@ -265,9 +290,9 @@ namespace CSM.Injections
     [HarmonyPatch]
     public class SetVehicleName
     {
-        public static void Prefix(object __instance, ref bool __state)
+        public static void Prefix(object __instance, out bool __state)
         {
-            NameHandler.CheckCounter(__instance, ref __state);
+            NameHandler.CheckCounter(__instance, out __state);
         }
         
         public static void Postfix(ushort ___vehicleID, string ___name, ref bool __state, object __instance)
@@ -292,9 +317,9 @@ namespace CSM.Injections
     [HarmonyPatch]
     public class SetParkedVehicleName
     {
-        public static void Prefix(object __instance, ref bool __state)
+        public static void Prefix(object __instance, out bool __state)
         {
-            NameHandler.CheckCounter(__instance, ref __state);
+            NameHandler.CheckCounter(__instance, out __state);
         }
         
         public static void Postfix(ushort ___parkedID, string ___name, ref bool __state, object __instance)
@@ -319,9 +344,9 @@ namespace CSM.Injections
     [HarmonyPatch]
     public class SetCityName
     {
-        public static void Prefix(object __instance, ref bool __state)
+        public static void Prefix(object __instance, out bool __state)
         {
-            NameHandler.CheckCounter(__instance, ref __state);
+            NameHandler.CheckCounter(__instance, out __state);
         }
         
         public static void Postfix(string ___name, ref bool __state)

--- a/src/Injections/RoadHandler.cs
+++ b/src/Injections/RoadHandler.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using CSM.Commands;
+using CSM.Common;
+using HarmonyLib;
+
+namespace CSM.Injections
+{
+    public static class RoadHandler
+    {
+        public static bool IgnoreAll { get; set; } = false;
+    }
+
+    [HarmonyPatch(typeof(RoadBaseAI))]
+    [HarmonyPatch("ClickNodeButton")]
+    public class ClickNodeButton
+    { 
+        public static void Prefix(ref NetNode data, int index, out int __state)
+        {
+            __state = -1;
+            
+            if (RoadHandler.IgnoreAll)
+                return;
+
+            __state = GetFlags(data, index);
+        }
+
+        public static void Postfix(ref NetNode data, int index, ushort nodeID, ref int __state)
+        {
+            if (__state == -1)
+                return;
+
+            int newFlags = GetFlags(data, index);
+            if (newFlags != -1 && newFlags != __state)
+            {
+                Command.SendToAll(new RoadSettingsCommand()
+                {
+                    NodeID = nodeID,
+                    Index = index
+                });
+            }
+        }
+
+        private static int GetFlags(NetNode data, int index)
+        {
+            if (index == -1) // Node modified (traffic lights)
+            {
+                return (int) data.m_flags;
+            }
+            else // Segment modified (stop sign)
+            {
+                ushort segment = data.GetSegment(index - 1);
+                if (segment != 0)
+                {
+                    return (int) NetManager.instance.m_segments.m_buffer[segment].m_flags;
+                }
+            }
+            
+            return -1;
+        }
+    }
+    
+    [HarmonyPatch]
+    public class SetPriorityRoad
+    {
+        public static void Prefix(object __instance, out bool __state)
+        {
+            int counter = ReflectionHelper.GetAttr<int>(__instance, "$PC");
+            __state = counter == 0;
+        }
+        
+        public static void Postfix(IEnumerator<bool> __instance, ref bool __state, ushort ___segmentID, bool ___priority)
+        {
+            if (RoadHandler.IgnoreAll || !__state)
+                return;
+
+            if (!ReflectionHelper.GetAttr<bool>(__instance, "$current"))
+                return;
+
+            Command.SendToAll(new RoadSetPriorityCommand
+            {
+                SegmentId = ___segmentID,
+                Priority = ___priority
+            });
+        }
+
+        public static MethodBase TargetMethod()
+        {
+            return ReflectionHelper.GetIteratorTargetMethod(typeof(NetManager), "<SetPriorityRoad>c__Iterator3", out Type _);
+        }
+    }
+}


### PR DESCRIPTION
(Needs to be rebased after #132 is pulled)

This pr implements synchronization of the name seeds for segments (=initial road names), road priority settings, stop signs and traffic lights.

- closes #122
- closes #124 

(@DominicMaas Don't worry about delaying the pull requests, and good luck with your exam. :smile: )