### PR TITLE
Implement syncing of transport line settings

### DIFF
--- a/src/CSM.csproj
+++ b/src/CSM.csproj
@@ -112,6 +112,10 @@
     <Compile Include="Commands\Data\TransportLines\TransportLineAddStopCommand.cs" />
     <Compile Include="Commands\Data\TransportLines\TransportLineCancelMoveStopCommand.cs" />
     <Compile Include="Commands\Data\TransportLines\TransportLineCancelPrevStopCommand.cs" />
+    <Compile Include="Commands\Data\TransportLines\TransportLineChangeActiveCommand.cs" />
+    <Compile Include="Commands\Data\TransportLines\TransportLineChangeColorCommand.cs" />
+    <Compile Include="Commands\Data\TransportLines\TransportLineChangeVehicleCommand.cs" />
+    <Compile Include="Commands\Data\TransportLines\TransportLineChangeSliderCommand.cs" />
     <Compile Include="Commands\Data\TransportLines\TransportLineCreateCommand.cs" />
     <Compile Include="Commands\Data\TransportLines\TransportLineInitCommand.cs" />
     <Compile Include="Commands\Data\TransportLines\TransportLineMoveStopCommand.cs" />
@@ -171,6 +175,10 @@
     <Compile Include="Commands\Handler\TransportLines\TransportLineAddStopHandler.cs" />
     <Compile Include="Commands\Handler\TransportLines\TransportLineCancelMoveStopHandler.cs" />
     <Compile Include="Commands\Handler\TransportLines\TransportLineCancelPrevStopHandler.cs" />
+    <Compile Include="Commands\Handler\TransportLines\TransportLineChangeActiveHandler.cs" />
+    <Compile Include="Commands\Handler\TransportLines\TransportLineChangeColorHandler.cs" />
+    <Compile Include="Commands\Handler\TransportLines\TransportLineChangeSliderHandler.cs" />
+    <Compile Include="Commands\Handler\TransportLines\TransportLineChangeVehicleHandler.cs" />
     <Compile Include="Commands\Handler\TransportLines\TransportLineCreateHandler.cs" />
     <Compile Include="Commands\Handler\TransportLines\TransportLineInitHandler.cs" />
     <Compile Include="Commands\Handler\TransportLines\TransportLineMoveStopHandler.cs" />

--- a/src/Commands/Data/TransportLines/TransportLineChangeActiveCommand.cs
+++ b/src/Commands/Data/TransportLines/TransportLineChangeActiveCommand.cs
@@ -1,0 +1,31 @@
+using ProtoBuf;
+
+namespace CSM.Commands.Data.TransportLines
+{ 
+    /// <summary>
+    ///     Called when the day/night settings of a transport line were changed.
+    /// </summary>
+    /// Sent by:
+    /// - TransportHandler
+    [ProtoContract]
+    public class TransportLineChangeActiveCommand : CommandBase
+    {
+        /// <summary>
+        ///     The id of the modified line
+        /// </summary>
+        [ProtoMember(1)]
+        public ushort LineId;
+
+        /// <summary>
+        ///     If the line is active at daytime.
+        /// </summary>
+        [ProtoMember(2)]
+        public bool Day;
+
+        /// <summary>
+        ///     If the line is active at nighttime.
+        /// </summary>
+        [ProtoMember(3)]
+        public bool Night;
+    }
+}

--- a/src/Commands/Data/TransportLines/TransportLineChangeColorCommand.cs
+++ b/src/Commands/Data/TransportLines/TransportLineChangeColorCommand.cs
@@ -1,0 +1,26 @@
+using ProtoBuf;
+using UnityEngine;
+
+namespace CSM.Commands.Data.TransportLines
+{
+    /// <summary>
+    ///     Called when the color of a transport line was changed.
+    /// </summary>
+    /// Sent by:
+    /// - TransportLine
+    [ProtoContract]
+    public class TransportLineChangeColorCommand : CommandBase
+    {
+        /// <summary>
+        ///     The id of the modified line.
+        /// </summary>
+        [ProtoMember(1)]
+        public ushort LineId { get; set; }
+        
+        /// <summary>
+        ///     The new color of the line.
+        /// </summary>
+        [ProtoMember(2)]
+        public Color Color { get; set; }
+    }
+}

--- a/src/Commands/Data/TransportLines/TransportLineChangeSliderCommand.cs
+++ b/src/Commands/Data/TransportLines/TransportLineChangeSliderCommand.cs
@@ -1,0 +1,33 @@
+using ProtoBuf;
+
+namespace CSM.Commands.Data.TransportLines
+{
+    /// <summary>
+    ///     Called when a slider in the transport line info window was changed.
+    ///     This covers the ticket price and vehicle count sliders.
+    /// </summary>
+    /// Sent by:
+    /// - TransportLine
+    [ProtoContract]
+    public class TransportLineChangeSliderCommand : CommandBase
+    {
+        /// <summary>
+        ///     The id of the line that was modified.
+        /// </summary>
+        [ProtoMember(1)]
+        public ushort LineId { get; set; }
+        
+        /// <summary>
+        ///     The new value of the slider.
+        /// </summary>
+        [ProtoMember(2)]
+        public float Value { get; set; }
+
+        /// <summary>
+        ///     If true: Ticket price slider was changed
+        ///     If false: Vehicle count slider was changed
+        /// </summary>
+        [ProtoMember(3)]
+        public bool IsTicketPrice { get; set; }
+    }
+}

--- a/src/Commands/Data/TransportLines/TransportLineChangeVehicleCommand.cs
+++ b/src/Commands/Data/TransportLines/TransportLineChangeVehicleCommand.cs
@@ -1,0 +1,25 @@
+using ProtoBuf;
+
+namespace CSM.Commands.Data.TransportLines
+{ 
+    /// <summary>
+    ///     Called when the vehicle type of a transport line was changed.
+    /// </summary>
+    /// Sent by:
+    /// - TransportHandler
+    [ProtoContract]
+    public class TransportLineChangeVehicleCommand : CommandBase
+    {
+        /// <summary>
+        ///     The id of the line that was modified.
+        /// </summary>
+        [ProtoMember(1)]
+        public ushort LineId;
+
+        /// <summary>
+        ///     The prefab info index of the new vehicle.
+        /// </summary>
+        [ProtoMember(2)]
+        public uint Vehicle;
+    }
+}

--- a/src/Commands/Handler/TransportLines/TransportLineChangeActiveHandler.cs
+++ b/src/Commands/Handler/TransportLines/TransportLineChangeActiveHandler.cs
@@ -1,0 +1,15 @@
+using CSM.Commands.Data.TransportLines;
+using CSM.Helpers;
+
+namespace CSM.Commands.Handler.TransportLines
+{
+    public class TransportLineChangeActiveHandler : CommandHandler<TransportLineChangeActiveCommand>
+    {
+        protected override void Handle(TransportLineChangeActiveCommand command)
+        {
+            IgnoreHelper.StartIgnore();
+            TransportManager.instance.m_lines.m_buffer[command.LineId].SetActive(command.Day, command.Night);
+            IgnoreHelper.EndIgnore();
+        }
+    }
+}

--- a/src/Commands/Handler/TransportLines/TransportLineChangeColorHandler.cs
+++ b/src/Commands/Handler/TransportLines/TransportLineChangeColorHandler.cs
@@ -1,0 +1,15 @@
+using CSM.Commands.Data.TransportLines;
+using CSM.Helpers;
+
+namespace CSM.Commands.Handler.TransportLines
+{
+    public class TransportLineChangeColorHandler : CommandHandler<TransportLineChangeColorCommand>
+    {
+        protected override void Handle(TransportLineChangeColorCommand command)
+        {
+            IgnoreHelper.StartIgnore();
+            TransportManager.instance.SetLineColor(command.LineId, command.Color).MoveNext();
+            IgnoreHelper.EndIgnore();
+        }
+    }
+}

--- a/src/Commands/Handler/TransportLines/TransportLineChangeSliderHandler.cs
+++ b/src/Commands/Handler/TransportLines/TransportLineChangeSliderHandler.cs
@@ -1,0 +1,39 @@
+using ColossalFramework;
+using ColossalFramework.UI;
+using CSM.Commands.Data.TransportLines;
+using CSM.Helpers;
+
+namespace CSM.Commands.Handler.TransportLines
+{
+    public class TransportLineChangeSliderHandler : CommandHandler<TransportLineChangeSliderCommand>
+    {
+        protected override void Handle(TransportLineChangeSliderCommand command)
+        {
+            IgnoreHelper.StartIgnore();
+
+            TransportLine[] lines = TransportManager.instance.m_lines.m_buffer;
+            if (command.IsTicketPrice)
+                lines[command.LineId].m_ticketPrice = (ushort) command.Value;
+            else
+                lines[command.LineId].m_budget = (ushort) command.Value;
+
+            // Update info panel if open:
+            PublicTransportWorldInfoPanel panel = UIView.library.Get<PublicTransportWorldInfoPanel>(typeof(PublicTransportWorldInfoPanel).Name);
+            ushort lineId = ReflectionHelper.Call<ushort>(panel, "GetLineID");
+            if (lineId == command.LineId)
+            {
+                UISlider slider = ReflectionHelper.GetAttr<UISlider>(panel, command.IsTicketPrice ? "m_ticketPriceSlider" : "m_vehicleCountModifier");
+
+                if (slider != null)
+                {
+                    SimulationManager.instance.m_ThreadingWrapper.QueueMainThread(() =>
+                    {
+                        slider.value = command.Value;
+                    });
+                }
+            }
+            
+            IgnoreHelper.EndIgnore();
+        }
+    }
+}

--- a/src/Commands/Handler/TransportLines/TransportLineChangeVehicleHandler.cs
+++ b/src/Commands/Handler/TransportLines/TransportLineChangeVehicleHandler.cs
@@ -1,0 +1,21 @@
+using CSM.Commands.Data.TransportLines;
+using CSM.Helpers;
+
+namespace CSM.Commands.Handler.TransportLines
+{
+    public class TransportLineChangeVehicleHandler : CommandHandler<TransportLineChangeVehicleCommand>
+    {
+        protected override void Handle(TransportLineChangeVehicleCommand command)
+        {
+            IgnoreHelper.StartIgnore();
+
+            // Use ref because otherwise the TransportLine struct(!) would be copied
+            ref TransportLine line = ref TransportManager.instance.m_lines.m_buffer[command.LineId];
+            VehicleInfo vehicle = PrefabCollection<VehicleInfo>.GetPrefab(command.Vehicle);
+
+            ReflectionHelper.Call(line, "ReplaceVehicles", command.LineId, vehicle);
+
+            IgnoreHelper.EndIgnore();
+        }
+    }
+}


### PR DESCRIPTION
This PR implements the synchronization of the following settings of transport lines:
- The active setting (day/night/both)
- The line color setting
- The vehicle setting of for example bus lines (normal/school bus)
- The vehicle count slider
- The ticket price slider (for tourist busses)