### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
 
 ---
 
@@ -19,6 +22,17 @@ A clear and concise description of what you expected to happen.
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
+
+**Active DLCs**
+Please add a list of your enabled DLCs here.
+
+**Active mods**
+Please add a list of your installed and enabled mods here.
+
+**Versions**
+Type /version into the in-game chat and paste the version numbers here:
+- Mod version: 
+- Game version: 
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/other-question.md
+++ b/.github/ISSUE_TEMPLATE/other-question.md
@@ -1,0 +1,10 @@
+---
+name: Other question
+about: A general question which is neither a bug report nor a feature request.
+title: ''
+labels: question
+assignees: ''
+
+---
+
+


### PR DESCRIPTION
To get higher quality issues, I changed the issue templates a bit:
- Added fields for mods, dlcs and version numbers to the bug report template
- Prevent users from easily opening completely empty issues
- But added an explicit option to create an "other question" issue