### PR TITLE
Implement slowdown when a client can't keep up

### DIFF
--- a/src/CSM.csproj
+++ b/src/CSM.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Commands\Data\Internal\FinishTransactionCommand.cs" />
     <Compile Include="Commands\Data\Internal\PlayerListCommand.cs" />
     <Compile Include="Commands\Data\Internal\RequestWorldTransferCommand.cs" />
+    <Compile Include="Commands\Data\Internal\SlowdownCommand.cs" />
     <Compile Include="Commands\Data\Internal\WorldTransferCommand.cs" />
     <Compile Include="Commands\Data\Names\ChangeCityNameCommand.cs" />
     <Compile Include="Commands\Data\Names\ChangeNameCommand.cs" />
@@ -190,6 +191,7 @@
     <Compile Include="Commands\Handler\Internal\PlayerListHandler.cs" />
     <Compile Include="Commands\Handler\Internal\PlayerLocationHandler.cs" />
     <Compile Include="Commands\Handler\Internal\RequestWorldTransferHandler.cs" />
+    <Compile Include="Commands\Handler\Internal\SlowdownHandler.cs" />
     <Compile Include="Commands\Handler\Internal\WorldTransferHandler.cs" />
     <Compile Include="Commands\Handler\Names\ChangeCityNameHandler.cs" />
     <Compile Include="Commands\Handler\Names\ChangeNameHandler.cs" />
@@ -240,6 +242,7 @@
     <Compile Include="Helpers\IgnoreHelper.cs" />
     <Compile Include="Helpers\InfoPanelHelper.cs" />
     <Compile Include="Helpers\ReflectionHelper.cs" />
+    <Compile Include="Helpers\SlowdownHelper.cs" />
     <Compile Include="Helpers\ToolSimulator.cs" />
     <Compile Include="Injections\ArrayHandler.cs" />
     <Compile Include="Injections\BuildingHandler.cs" />
@@ -252,6 +255,7 @@
     <Compile Include="Injections\NetHandler.cs" />
     <Compile Include="Injections\PropHandler.cs" />
     <Compile Include="Injections\RoadHandler.cs" />
+    <Compile Include="Injections\TickLoopHandler.cs" />
     <Compile Include="Injections\TerrainHandler.cs" />
     <Compile Include="Injections\TransportHandler.cs" />
     <Compile Include="Injections\TreeHandler.cs" />

--- a/src/Commands/Data/Internal/SlowdownCommand.cs
+++ b/src/Commands/Data/Internal/SlowdownCommand.cs
@@ -1,0 +1,19 @@
+using ProtoBuf;
+
+namespace CSM.Commands.Data.Internal
+{
+    /// <summary>
+    ///     Sends the number of dropped frames to the other clients (every two seconds).
+    /// </summary>
+    /// Sent by:
+    /// - TickLoopHandler
+    [ProtoContract]
+    public class SlowdownCommand : CommandBase
+    {
+        /// <summary>
+        ///     The number of dropped frames.
+        /// </summary>
+        [ProtoMember(1)]
+        public int DroppedFrames { get; set; }
+    }
+}

--- a/src/Commands/Handler/Internal/SlowdownHandler.cs
+++ b/src/Commands/Handler/Internal/SlowdownHandler.cs
@@ -1,0 +1,18 @@
+﻿using CSM.Commands.Data.Internal;
+using CSM.Helpers;
+
+namespace CSM.Commands.Handler.Internal
+{
+    public class SlowdownHandler : CommandHandler<SlowdownCommand>
+    {
+        public SlowdownHandler()
+        {
+            TransactionCmd = false;
+        }
+
+        protected override void Handle(SlowdownCommand command)
+        {
+            SlowdownHelper.AddDropFrames(command.DroppedFrames);
+        }
+    }
+}

--- a/src/Extensions/ThreadingExtension.cs
+++ b/src/Extensions/ThreadingExtension.cs
@@ -4,6 +4,7 @@ using CSM.Injections;
 using CSM.Networking;
 using ICities;
 using System;
+using CSM.Helpers;
 
 namespace CSM.Extensions
 {
@@ -14,7 +15,7 @@ namespace CSM.Extensions
     {
         private int _lastSelectedSimulationSpeed;
         private bool _lastSimulationPausedState;
-        private DateTime lastEconomySync;
+        private DateTime _lastEconomyAndDropSync;
 
         public override void OnBeforeSimulationTick()
         {
@@ -55,10 +56,11 @@ namespace CSM.Extensions
             _lastSelectedSimulationSpeed = SimulationManager.instance.SelectedSimulationSpeed;
 
             // Send economy packets every two seconds
-            if (DateTime.Now.Subtract(lastEconomySync).TotalSeconds > 2)
+            if (DateTime.Now.Subtract(_lastEconomyAndDropSync).TotalSeconds > 2)
             {
                 ResourceCommandHandler.Send();
-                lastEconomySync = DateTime.Now;
+                SlowdownHelper.SendDroppedFrames();
+                _lastEconomyAndDropSync = DateTime.Now;
             }
 
             // Finish transactions

--- a/src/Helpers/SlowdownHelper.cs
+++ b/src/Helpers/SlowdownHelper.cs
@@ -1,0 +1,96 @@
+using CSM.Commands;
+using CSM.Commands.Data.Internal;
+using NLog;
+using UnityEngine;
+
+namespace CSM.Helpers
+{
+    /// <summary>
+    ///     This class takes care of slowing the game down if another player's game runs too slow.
+    ///     This happens by keeping track of dropped frames on the slower client and also
+    ///     dropping them on the other clients.
+    /// </summary>
+    public static class SlowdownHelper
+    {
+        private static readonly NLog.Logger _logger = LogManager.GetCurrentClassLogger();
+
+        private static int _locallyDroppedFrames = 0;
+        private static readonly object _localDropLock = new object();
+
+        private static int _framesToDrop = 0;
+        private static readonly object _toDropLock = new object();
+        private static int _dropInterval;
+        private static int _curTickInc = 0;
+        
+        /// <summary>
+        ///     Called by the TickLoopHandler when a frame was dropped.
+        ///     Increases the queued dropped frame count that will later be sent to other clients.
+        /// </summary>
+        public static void FrameDropped()
+        {
+            lock (_localDropLock)
+            {
+                _locallyDroppedFrames++;
+            }
+        }
+
+        /// <summary>
+        ///     Send queued dropped frame count to other clients.
+        /// </summary>
+        public static void SendDroppedFrames()
+        {
+            int dropped;
+            lock (_localDropLock)
+            {
+                dropped = _locallyDroppedFrames;
+                _locallyDroppedFrames = 0;
+            }
+
+            if (dropped > 0)
+            {
+                _logger.Debug($"{dropped} dropped frames!");
+                Command.SendToAll(new SlowdownCommand()
+                {
+                    DroppedFrames = dropped
+                });
+            }
+        }
+
+        /// <summary>
+        ///     Adds a number of frames to drop (they were dropped on another client).
+        ///     Also computes the _dropInterval at which the frames will be dropped.
+        ///     It is chosen so that the queued frames are evenly dropped within ten seconds.
+        /// </summary>
+        /// <param name="frames">The number of frames.</param>
+        public static void AddDropFrames(int frames)
+        {
+            int ticksUntil = (int) (10 * (1 / Time.fixedDeltaTime)); // 10 seconds * ticks per second (1/tick interval)
+            lock (_toDropLock)
+            {
+                _framesToDrop += frames;
+                _dropInterval = ticksUntil / _framesToDrop;
+            }
+            _logger.Debug($"Dropping {_framesToDrop} frames in the next 10 seconds (drop every {_dropInterval} frames)");
+        }
+
+        /// <summary>
+        ///     Checks if a frame needs to be dropped.
+        ///     Every _dropInterval a frame is dropped.
+        /// </summary>
+        /// <returns>If the current frame needs to be dropped.</returns>
+        public static bool CheckDropAndReduce()
+        {
+            _curTickInc++;
+            lock (_toDropLock)
+            {
+                if (_framesToDrop > 0 && _curTickInc >= _dropInterval)
+                {
+                    _framesToDrop--;
+                    _curTickInc = 0;
+                    return true;
+                }
+                return false;
+            }
+        }
+    }
+}

--- a/src/Injections/TickLoopHandler.cs
+++ b/src/Injections/TickLoopHandler.cs
@@ -1,0 +1,47 @@
+using System.Threading;
+using CSM.Helpers;
+using HarmonyLib;
+
+namespace CSM.Injections
+{
+    /// <summary>
+    ///     Replaces the SimulationManager.FixedUpdate method with a method with
+    ///     some additional logic for dropping frames when needed.
+    /// </summary>
+    [HarmonyPatch(typeof(SimulationManager))]
+    [HarmonyPatch("FixedUpdate")]
+    public class TickLoopHandler
+    {
+        public static bool Prefix(object ___m_simulationFrameLock, ref int ___m_updateCounter, int ___m_maxFramesBehind, bool ___m_simulationPaused)
+        {
+            while (!Monitor.TryEnter(___m_simulationFrameLock, SimulationManager.SYNCHRONIZE_TIMEOUT))
+            {
+            }
+            try
+            {
+                // Check if a frame should be dropped
+                if (!SlowdownHelper.CheckDropAndReduce())
+                {
+                    // Check if frame should be queued or dropped (original cities code)
+                    if (___m_updateCounter < ___m_maxFramesBehind)
+                    {
+                        ___m_updateCounter++;
+                        Monitor.Pulse(___m_simulationFrameLock);
+                    }
+                    else if (!___m_simulationPaused)
+                    {
+                        // Increase dropped frame count (only when running, we don't care about dropped frames during pause)
+                        SlowdownHelper.FrameDropped();
+                    }
+                }
+            }
+            finally
+            {
+                Monitor.Exit(___m_simulationFrameLock);
+            }
+
+            // Don't run original method
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
This will sync the game speed of all connected clients (which may be reduced due to a slow computer).

### Explanation
Cities has a "pending frames" counter of tick frames that still need to performed. The counter is increased by the FixedUpdate method that gets regularly called by Unity (60 times per second). If this number gets to large (e.g. the frames can't be computed fast enough), no new frames are added on top ("dropped frames"), so the game performs less ticks per second.

These dropped frames are now synced so that every client drops them. To prevent the game from stopping every time it receives a new number of frames to drop, the frames to drop are spread evenly over ten seconds which results in a smooth slowdown.

Dropping frames is realized by not adding a frame to the "pending frames" counter every x frames, where x is determined by the total number of frames to drop and the interval of ten seconds.

One could argue that when two or more clients are dropping frames the game will run slower than needed (because both clients add up). This isn't a real problem though, because the frames that are skipped by this implementation give the client more time to execute it's pending frames, which leads to fewer dropped frames on that client. So the actual number of dropped frames will level out so that the speed fits for the slowest client.

### Notes
- Please merge #191 before this.
- Closes #154 
- This implementation still doesn't sync the game perfectly on pause or speed changes due to network latency. This will be fixed in a later pull request.