### PR TITLE
Added chat auto-close timeout.

### DIFF
--- a/src/Panels/ChatLogPanel.cs
+++ b/src/Panels/ChatLogPanel.cs
@@ -33,7 +33,7 @@ namespace CSM.Panels
 
         private readonly List<ChatCommand> _chatCommands;
 
-        private int _timeoutCounter;
+        private float _timeoutCounter;
 
         public enum MessageType
         {

--- a/src/Panels/ChatLogPanel.cs
+++ b/src/Panels/ChatLogPanel.cs
@@ -412,11 +412,15 @@ namespace CSM.Panels
                     ChatLogPanel chatPanel = UIView.GetAView().FindUIComponent<ChatLogPanel>("ChatLogPanel");
                     if (chatPanel != null && !chatPanel.isVisible)
                     {
-                        chatPanel.isVisible = true;
-                        chatPanel.Update();
-
-                        // Reset the timeout counter
+                        // Reset the timeout counter when a new message is recieved
                         chatPanel._timeoutCounter = 0;
+
+                        // If the panel is closed, make sure it gets shown
+                        if(!chatPanel.isVisible)
+                        {
+                            chatPanel.isVisible = true;
+                            chatPanel.Update();
+                        }
                     }
 
                     UILabel messageBox = UIView.GetAView().FindUIComponent<UILabel>("ChatLogPanelMessageBox");

--- a/src/Panels/ChatLogPanel.cs
+++ b/src/Panels/ChatLogPanel.cs
@@ -33,6 +33,8 @@ namespace CSM.Panels
 
         private readonly List<ChatCommand> _chatCommands;
 
+        private int _timeoutCounter;
+
         public enum MessageType
         {
             Normal,
@@ -120,6 +122,20 @@ namespace CSM.Panels
             {
                  isVisible = true;
                 _chatText.Focus();
+
+                // Reset the timeout counter
+                _timeoutCounter = 0;
+            }
+
+            // Increment the timeout counter if panel is visible
+            // note: Timer is framerate dependent!!! ColossalFramework has no delta time,
+            // could be done crudely, but this seems sufficient.
+            if(isVisible) _timeoutCounter ++;
+
+            // If timeout counter has timed out, hide chat.
+            if(_timeoutCounter > 40000) {
+                isVisible = false;
+                _timeoutCounter = 0;
             }
 
             base.Update();
@@ -271,6 +287,9 @@ namespace CSM.Panels
         
         private void OnChatKeyDown(UIComponent component, UIKeyEventParameter eventParam)
         {
+            // Reset chat timeout
+            _timeoutCounter = 0;
+
             // Run this code when the user presses the enter key
             if (eventParam.keycode == KeyCode.Return || eventParam.keycode == KeyCode.KeypadEnter)
             {
@@ -383,6 +402,9 @@ namespace CSM.Panels
         /// <param name="msg">The message.</param>
         public static void PrintChatMessage(string username, string msg)
         {
+            // Reset the timeout counter
+            _timeoutCounter = 0;
+
             PrintMessage($"<{username}> {msg}");
         }
 

--- a/src/Panels/ChatLogPanel.cs
+++ b/src/Panels/ChatLogPanel.cs
@@ -128,12 +128,10 @@ namespace CSM.Panels
             }
 
             // Increment the timeout counter if panel is visible
-            // note: Timer is framerate dependent!!! ColossalFramework has no delta time,
-            // could be done crudely, but this seems sufficient.
-            if(isVisible) _timeoutCounter ++;
+            if(isVisible && !_chatText.hasFocus) _timeoutCounter += Time.deltaTime;
 
             // If timeout counter has timed out, hide chat.
-            if(_timeoutCounter > 40000) {
+            if(_timeoutCounter > 5) {
                 isVisible = false;
                 _timeoutCounter = 0;
             }
@@ -402,9 +400,6 @@ namespace CSM.Panels
         /// <param name="msg">The message.</param>
         public static void PrintChatMessage(string username, string msg)
         {
-            // Reset the timeout counter
-            _timeoutCounter = 0;
-
             PrintMessage($"<{username}> {msg}");
         }
 
@@ -419,6 +414,9 @@ namespace CSM.Panels
                     {
                         chatPanel.isVisible = true;
                         chatPanel.Update();
+
+                        // Reset the timeout counter
+                        chatPanel._timeoutCounter = 0;
                     }
 
                     UILabel messageBox = UIView.GetAView().FindUIComponent<UILabel>("ChatLogPanelMessageBox");

--- a/src/Panels/ChatLogPanel.cs
+++ b/src/Panels/ChatLogPanel.cs
@@ -410,13 +410,13 @@ namespace CSM.Panels
                 SimulationManager.instance.m_ThreadingWrapper.QueueMainThread(() =>
                 {
                     ChatLogPanel chatPanel = UIView.GetAView().FindUIComponent<ChatLogPanel>("ChatLogPanel");
-                    if (chatPanel != null && !chatPanel.isVisible)
+                    if (chatPanel != null)
                     {
                         // Reset the timeout counter when a new message is recieved
                         chatPanel._timeoutCounter = 0;
 
                         // If the panel is closed, make sure it gets shown
-                        if(!chatPanel.isVisible)
+                        if(!chatPanel.isVisible)    
                         {
                             chatPanel.isVisible = true;
                             chatPanel.Update();


### PR DESCRIPTION
Improvement of chat, according to suggestion #201. Autocloses after a few updates, if the chat hasn't been updated or any input has been given. 

I used a simple implementation of a counter in the update method. One could use C# `Timer`s, but it became easier to interrupt this way.

Limitation:
Since i couldn't find a way to get delta time in the `UIPanel` using `ColossalFramework`, this implementation is framerate dependent. delta time could be done crudely, but due to the added complexity and overhead this seemed unnecessary.

The timeout duration may need tweaking.


NOTE:
Not sure if the CI is working correctly. Failed at deleting unused artifacts.
