### PR TITLE
Fix speed and pause issues

### DIFF
--- a/src/Commands/Handler/Game/SpeedPauseReachedHandler.cs
+++ b/src/Commands/Handler/Game/SpeedPauseReachedHandler.cs
@@ -23,6 +23,11 @@ namespace CSM.Commands.Handler.Game
                 {
                     SpeedPauseHelper.StateReached();
                     _currentWaitingId = -1;
+
+                    // Allow the response handler to process new requests
+                    // We need to wait until now because responses of conflicting requests
+                    // could arrive during the waiting phase, but need to be discarded.
+                    SpeedPauseResponseHandler.ResetWaitingId();
                 }
             }
         }

--- a/src/Commands/Handler/Game/SpeedPauseRequestHandler.cs
+++ b/src/Commands/Handler/Game/SpeedPauseRequestHandler.cs
@@ -1,5 +1,7 @@
 ﻿using CSM.Commands.Data.Game;
 using CSM.Helpers;
+using CSM.Networking;
+using CSM.Networking.Status;
 
 namespace CSM.Commands.Handler.Game
 {
@@ -12,6 +14,14 @@ namespace CSM.Commands.Handler.Game
 
         protected override void Handle(SpeedPauseRequestCommand command)
         {
+            // If we are a client but not yet connected, don't answer as we're not counted towards
+            // the "number of required consenting clients" until we are done with loading
+            if (MultiplayerManager.Instance.CurrentRole == MultiplayerRole.Client &&
+                MultiplayerManager.Instance.CurrentClient.Status != ClientStatus.Connected)
+            {
+                return;
+            }
+
             SpeedPauseHelper.PlayPauseRequest(command.SimulationPaused, command.SelectedSimulationSpeed, command.RequestId);
         }
     }

--- a/src/Commands/Handler/Game/SpeedPauseResponseHandler.cs
+++ b/src/Commands/Handler/Game/SpeedPauseResponseHandler.cs
@@ -1,12 +1,11 @@
 ﻿using CSM.Commands.Data.Game;
 using CSM.Helpers;
-using CSM.Util;
 
 namespace CSM.Commands.Handler.Game
 {
     public class SpeedPauseResponseHandler : CommandHandler<SpeedPauseResponseCommand>
     {
-        private int _currentWaitingId;
+        private static int _currentWaitingId;
         private int _maxNumberOfClients;
         private int _numberOfClients;
         private long _highestLatency;
@@ -60,9 +59,6 @@ namespace CSM.Commands.Handler.Game
                 
                 // Set waiting target for the SpeedPauseReachedCommand
                 SpeedPauseReachedHandler.SetWaitingFor(_currentWaitingId, _maxNumberOfClients);
-
-                // Reset waiting id
-                _currentWaitingId = -1;
             }
         }
 
@@ -73,6 +69,11 @@ namespace CSM.Commands.Handler.Game
             _numberOfClients = 0;
             _highestLatency = -1;
             _highestTime = -1;
+        }
+
+        public static void ResetWaitingId()
+        {
+            _currentWaitingId = -1;
         }
     }
 }


### PR DESCRIPTION
- Don't allow new SpeedPauseResponses until the requested states have been reached
This will fix issues with multiple simultaneous button presses
- Don't wait for answers of connecting clients to pause the game
- Handle play requests just like other requests to be able to wait for completion

This should now mostly keep the games in sync and allow both players again to pause, unpause and change the speed of the game.

Fixes #213