### PR TITLE
Alter build script to support Epic Games installations

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -95,22 +95,22 @@ If ($Update)
     Write-Host "[CSM Update Script] Please Note: This may break the mod if any major game changes have occured."
 
     # Get the steam directory
-    $SteamDirectory = Read-Host "[CSM Update Script] Please enter your steam folder directory (not steamapps). For example, 'C:\Program Files\Steam\'" 
+    $GameDirectory = Read-Host "[CSM Update Script] Please enter your game folder directory. For example, for Windows, 'C:\Program Files\Steam\steamapps\common\Cities_Skylines' for Steam or 'C:\Program Files\Epic Games\CitiesSkylines' for Epic Games." 
 
     If ($IsMacOS)
     {
         # Full folder path
-        $AssemblyDirectory = $SteamDirectory.TrimEnd($Sep) + "$($Sep)steamapps$($Sep)common$($Sep)Cities_Skylines$($Sep)Cities.App$($Sep)Contents$($Sep)Resources$($Sep)Data$($Sep)Managed$($Sep)"
+        $AssemblyDirectory = $GameDirectory.TrimEnd($Sep) + "$($Sep)Cities.App$($Sep)Contents$($Sep)Resources$($Sep)Data$($Sep)Managed$($Sep)"
     }
     Else
     {
         # Full folder path
-        $AssemblyDirectory = $SteamDirectory.TrimEnd($Sep) + "$($Sep)SteamApps$($Sep)common$($Sep)Cities_Skylines$($Sep)Cities_Data$($Sep)Managed$($Sep)"
+        $AssemblyDirectory = $GameDirectory.TrimEnd($Sep) + "$($Sep)Cities_Data$($Sep)Managed$($Sep)"
 
         # Try with lowercase SteamApps (linux)
         if (!(Test-Path -Path $AssemblyDirectory))
         {
-            $AssemblyDirectory = $SteamDirectory.TrimEnd($Sep) + "$($Sep)steamapps$($Sep)common$($Sep)Cities_Skylines$($Sep)Cities_Data$($Sep)Managed$($Sep)"
+            $AssemblyDirectory = $GameDirectory.TrimEnd($Sep) + "$($Sep)Cities_Data$($Sep)Managed$($Sep)"
         }
     }
 


### PR DESCRIPTION
This changes the behavior of the build script, it now asks for the complete game directory. Which means that inputting `C:\Program Files\Epic Games\CitiesSkylines` for Epic Games will work too.

This does change the path that users will have to input for Steam from `C:\Program Files\Steam\` to `C:\Program Files\Steam\steamapps\common\Cities_Skylines`, but that is listed for simplicity.