### PR TITLE
Multiplayer menu fixes

### DIFF
--- a/src/CSM.csproj
+++ b/src/CSM.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -254,6 +254,7 @@
     <Compile Include="Injections\EventHandler.cs" />
     <Compile Include="Injections\ICameraHandler.cs" />
     <Compile Include="Injections\MainMenuHandler.cs" />
+    <Compile Include="Injections\PauseMenuHandler.cs" />
     <Compile Include="Injections\EconomyHandler.cs" />
     <Compile Include="Injections\NameHandler.cs" />
     <Compile Include="Injections\NetHandler.cs" />

--- a/src/Extensions/LoadingExtension.cs
+++ b/src/Extensions/LoadingExtension.cs
@@ -1,15 +1,12 @@
-﻿using ColossalFramework;
-using ColossalFramework.Plugins;
-using ColossalFramework.UI;
+﻿using ColossalFramework.UI;
 using CSM.Commands;
 using CSM.Commands.Data.Internal;
-using CSM.Helpers;
 using CSM.Networking;
 using CSM.Networking.Status;
 using CSM.Panels;
+using CSM.Injections;
 using ICities;
 using System;
-using UnityEngine;
 using Object = UnityEngine.Object;
 
 namespace CSM.Extensions
@@ -34,43 +31,11 @@ namespace CSM.Extensions
                 Command.SendToServer(new ClientLevelLoadedCommand());
             }
 
-            UIButton resumeButton = UIView.GetAView()?.FindUIComponent("Resume") as UIButton;
-
-            // Check if resume button exists.
-            if (resumeButton == null)
-            {
-                return;
-            }
-
-            // Set btn text.
-            resumeButton.text = "MULTIPLAYER";
-            
-            // Add additional eventClick.
-            resumeButton.eventClick += (s, e) =>
-            {
-                // Open host game menu if not in multiplayer session, else open connection panel
-                if (MultiplayerManager.Instance.CurrentRole == MultiplayerRole.None)
-                {
-                    PanelManager.TogglePanel<HostGamePanel>();
-
-                    // Display warning if DLCs or other mods are enabled
-                    if (DLCHelper.GetOwnedDLCs() != SteamHelper.DLC_BitMask.None ||
-                        Singleton<PluginManager>.instance.enabledModCount > 1)
-                    {
-                        MessagePanel msgPanel = PanelManager.ShowPanel<MessagePanel>();
-                        msgPanel.DisplayContentWarning();
-                    }
-                }
-                else
-                {
-                    PanelManager.TogglePanel<ConnectionPanel>();
-                }
-            };
-
-            UIView uiView = UIView.GetAView();
-
             // Add the chat log
-            uiView.AddUIComponent(typeof(ChatLogPanel));
+            UIView.GetAView().AddUIComponent(typeof(ChatLogPanel));
+
+            // Setup Pause menu.
+            PauseMenuHandler.CreateOrUpdateMultiplayerButton();
         }
 
         public override void OnLevelUnloading()

--- a/src/Extensions/LoadingExtension.cs
+++ b/src/Extensions/LoadingExtension.cs
@@ -16,8 +16,6 @@ namespace CSM.Extensions
 {
     public class LoadingExtension : LoadingExtensionBase
     {
-        private UIButton _multiplayerButton;
-
         public override void OnReleased()
         {
             // Stop everything
@@ -36,36 +34,19 @@ namespace CSM.Extensions
                 Command.SendToServer(new ClientLevelLoadedCommand());
             }
 
-            UIView uiView = UIView.GetAView();
+            UIButton resumeButton = UIView.GetAView()?.FindUIComponent("Resume") as UIButton;
 
-            // Add the chat log
-            uiView.AddUIComponent(typeof(ChatLogPanel));
+            // Check if resume button exists.
+            if (resumeButton == null)
+            {
+                return;
+            }
 
-            _multiplayerButton = (UIButton)uiView.AddUIComponent(typeof(UIButton));
-
-            _multiplayerButton.text = "Multiplayer";
-            _multiplayerButton.width = 150;
-            _multiplayerButton.height = 40;
-
-            _multiplayerButton.normalBgSprite = "ButtonMenu";
-            _multiplayerButton.disabledBgSprite = "ButtonMenuDisabled";
-            _multiplayerButton.hoveredBgSprite = "ButtonMenuHovered";
-            _multiplayerButton.focusedBgSprite = "ButtonMenuFocused";
-            _multiplayerButton.pressedBgSprite = "ButtonMenuPressed";
-            _multiplayerButton.textColor = new Color32(255, 255, 255, 255);
-            _multiplayerButton.disabledTextColor = new Color32(7, 7, 7, 255);
-            _multiplayerButton.hoveredTextColor = new Color32(7, 132, 255, 255);
-            _multiplayerButton.focusedTextColor = new Color32(255, 255, 255, 255);
-            _multiplayerButton.pressedTextColor = new Color32(30, 30, 44, 255);
-
-            // Enable button sounds.
-            _multiplayerButton.playAudioEvents = true;
-
-            // Place the button.
-            _multiplayerButton.transformPosition = new Vector3(-1.45f, 0.97f);
-
-            // Respond to button click.
-            _multiplayerButton.eventClick += (component, param) =>
+            // Set btn text.
+            resumeButton.text = "MULTIPLAYER";
+            
+            // Add additional eventClick.
+            resumeButton.eventClick += (s, e) =>
             {
                 // Open host game menu if not in multiplayer session, else open connection panel
                 if (MultiplayerManager.Instance.CurrentRole == MultiplayerRole.None)
@@ -84,9 +65,12 @@ namespace CSM.Extensions
                 {
                     PanelManager.TogglePanel<ConnectionPanel>();
                 }
-
-                _multiplayerButton.Unfocus();
             };
+
+            UIView uiView = UIView.GetAView();
+
+            // Add the chat log
+            uiView.AddUIComponent(typeof(ChatLogPanel));
         }
 
         public override void OnLevelUnloading()

--- a/src/Injections/PauseMenuHandler.cs
+++ b/src/Injections/PauseMenuHandler.cs
@@ -1,0 +1,120 @@
+﻿using ColossalFramework;
+using ColossalFramework.Plugins;
+using ColossalFramework.UI;
+using CSM.Helpers;
+using CSM.Networking;
+using CSM.Panels;
+using CSM.Util;
+using HarmonyLib;
+using UnityEngine;
+
+namespace CSM.Injections
+{
+    [HarmonyPatch(typeof(PauseMenu))]
+    [HarmonyPatch("Initialize")]
+    public class PauseMenuInitialize
+    {
+        /// <summary>
+        ///     This handler is used to place the 'MULTIPLAYER' button to the top
+        ///     of the pause menu.
+        /// </summary>
+        public static void Prefix()
+        {
+            PauseMenuHandler.CreateOrUpdateMultiplayerButton();
+        }
+
+        public static void Postfix()
+        {
+            PauseMenuHandler.SetMenuHeight();
+        }
+    }
+
+    public class PauseMenuHandler
+    {
+        public static void CreateOrUpdateMultiplayerButton()
+        {
+            Log.Info("Creating multiplayer button...");
+
+            // Find pause menu view.
+            UIPanel pauseUiPanel = UIView.GetAView()?.FindUIComponent("Menu") as UIPanel;
+
+            if (pauseUiPanel == null)
+                return;
+
+            // Find button.
+            UIButton _multiplayerButton = UIView.GetAView().FindUIComponent("Multiplayer") as UIButton;
+
+            // Find divider.
+            UIPanel _multiplayerDivider = UIView.GetAView().FindUIComponent("multiplayerDivider") as UIPanel;
+
+            // Add the button & divider if it does not exist and assign
+            // the click event.
+            if (_multiplayerButton == null)
+            {
+                // Add multiplayer button.
+                _multiplayerButton = (UIButton)pauseUiPanel.AddUIComponent(typeof(UIButton));
+
+                // Add multiplayer divider.
+                _multiplayerDivider = (UIPanel)pauseUiPanel.AddUIComponent(typeof(UIPanel));
+
+                // Respond to button click.
+                _multiplayerButton.eventClick += (component, param) =>
+                {
+                    // Close pause menu.
+                    ReflectionHelper.Call(new PauseMenu(), "Resume");
+
+                    // Open host game menu if not in multiplayer session, else open connection panel
+                    if (MultiplayerManager.Instance.CurrentRole == MultiplayerRole.None)
+                    {
+                        PanelManager.TogglePanel<HostGamePanel>();
+
+                        // Display warning if DLCs or other mods are enabled
+                        if (DLCHelper.GetOwnedDLCs() != SteamHelper.DLC_BitMask.None ||
+                            Singleton<PluginManager>.instance.enabledModCount > 1)
+                        {
+                            MessagePanel msgPanel = PanelManager.ShowPanel<MessagePanel>();
+                            msgPanel.DisplayContentWarning();
+                        }
+                    }
+                    else
+                    {
+                        PanelManager.TogglePanel<ConnectionPanel>();
+                    }
+                };
+            }
+
+            // Set multiplayer button properties.
+            _multiplayerButton.name = "Multiplayer";
+            _multiplayerButton.text = "MULTIPLAYER";
+            _multiplayerButton.width = 310;
+            _multiplayerButton.height = 57;
+            _multiplayerButton.textScale = 1.25f;
+            _multiplayerButton.normalBgSprite = "ButtonMenu";
+            _multiplayerButton.disabledBgSprite = "ButtonMenuDisabled";
+            _multiplayerButton.hoveredBgSprite = "ButtonMenuHovered";
+            _multiplayerButton.focusedBgSprite = "ButtonMenuFocused";
+            _multiplayerButton.pressedBgSprite = "ButtonMenuPressed";
+            _multiplayerButton.textColor = new Color32(255, 255, 255, 255);
+            _multiplayerButton.disabledTextColor = new Color32(7, 7, 7, 255);
+            _multiplayerButton.hoveredTextColor = new Color32(7, 132, 255, 255);
+            _multiplayerButton.focusedTextColor = new Color32(255, 255, 255, 255);
+            _multiplayerButton.pressedTextColor = new Color32(30, 30, 44, 255);
+
+            // Set multiplayer divider properties.
+            _multiplayerDivider.height = 7;
+            _multiplayerDivider.name = "multiplayerDivider";
+
+            // Enable button sounds.
+            _multiplayerButton.playAudioEvents = true;
+        }
+
+        internal static void SetMenuHeight()
+        {
+            // Find pause menu view.
+            UIPanel pauseUiPanel = UIView.GetAView()?.FindUIComponent("Menu") as UIPanel;
+
+            // Set menu height.
+            pauseUiPanel.parent.height = 580;
+        }
+    }
+}

--- a/src/Panels/ConnectionPanel.cs
+++ b/src/Panels/ConnectionPanel.cs
@@ -86,6 +86,15 @@ namespace CSM.Panels
             RefreshState();
         }
 
+        public override void Update()
+        {
+            // Check if escape is pressed and panel is visible.
+            if (isVisible && Input.GetKeyDown(KeyCode.Escape))
+            {
+                isVisible = false;
+            }
+        }
+
         /// <summary>
         ///     Refresh which buttons should be displayed on the user interface
         /// </summary>

--- a/src/Panels/HostGamePanel.cs
+++ b/src/Panels/HostGamePanel.cs
@@ -111,6 +111,15 @@ namespace CSM.Panels
             };
         }
 
+        public override void Update()
+        {
+            // Check if escape is pressed and panel is visible.
+            if (isVisible && Input.GetKeyDown(KeyCode.Escape))
+            {
+                isVisible = false;
+            }
+        }
+
         private void RequestIPs()
         {
             // Request ips


### PR DESCRIPTION
Fixes #223.

Fixed multiplayer menu so that it now closes when pressing escape.

Moved the multiplayer menu to the pause menu replacing the resume game button. 

Result:
![CSM-hostgame](https://user-images.githubusercontent.com/17964845/105973464-0d9d4d00-608d-11eb-9154-a014b938c826.jpg)
