### PR TITLE
Speed/pause fixes

### DIFF
--- a/src/CSM.csproj
+++ b/src/CSM.csproj
@@ -260,6 +260,7 @@
     <Compile Include="Injections\NetHandler.cs" />
     <Compile Include="Injections\PropHandler.cs" />
     <Compile Include="Injections\RoadHandler.cs" />
+    <Compile Include="Injections\SpeedPauseHandler.cs" />
     <Compile Include="Injections\TickLoopHandler.cs" />
     <Compile Include="Injections\TerrainHandler.cs" />
     <Compile Include="Injections\TransportHandler.cs" />

--- a/src/Commands/Handler/Game/SpeedPauseRequestHandler.cs
+++ b/src/Commands/Handler/Game/SpeedPauseRequestHandler.cs
@@ -14,10 +14,9 @@ namespace CSM.Commands.Handler.Game
 
         protected override void Handle(SpeedPauseRequestCommand command)
         {
-            // If we are a client but not yet connected, don't answer as we're not counted towards
+            // If we are not yet connected don't answer as we're not counted towards
             // the "number of required consenting clients" until we are done with loading
-            if (MultiplayerManager.Instance.CurrentRole == MultiplayerRole.Client &&
-                MultiplayerManager.Instance.CurrentClient.Status != ClientStatus.Connected)
+            if (!MultiplayerManager.Instance.IsConnected())
             {
                 return;
             }

--- a/src/Commands/Handler/Internal/PlayerLocationHandler.cs
+++ b/src/Commands/Handler/Internal/PlayerLocationHandler.cs
@@ -15,9 +15,7 @@ namespace CSM.Commands.Handler.Internal
 
         protected override void Handle(PlayerLocationCommand command)
         {
-            if (MultiplayerManager.Instance.CurrentRole == MultiplayerRole.None ||
-                (MultiplayerManager.Instance.CurrentRole == MultiplayerRole.Client &&
-                MultiplayerManager.Instance.CurrentClient.Status != ClientStatus.Connected))
+            if (!MultiplayerManager.Instance.IsConnected())
             {
                 // Ignore packets while not connected
                 return;

--- a/src/Extensions/LoadingExtension.cs
+++ b/src/Extensions/LoadingExtension.cs
@@ -7,6 +7,8 @@ using CSM.Panels;
 using CSM.Injections;
 using ICities;
 using System;
+using CSM.Commands.Handler.Game;
+using CSM.Helpers;
 using Object = UnityEngine.Object;
 
 namespace CSM.Extensions
@@ -25,6 +27,8 @@ namespace CSM.Extensions
         {
             base.OnLevelLoaded(mode);
 
+            ResetData();
+
             if (MultiplayerManager.Instance.CurrentRole == MultiplayerRole.Client)
             {
                 MultiplayerManager.Instance.CurrentClient.Status = ClientStatus.Connected;
@@ -36,6 +40,21 @@ namespace CSM.Extensions
 
             // Setup Pause menu.
             PauseMenuHandler.CreateOrUpdateMultiplayerButton();
+        }
+
+        private void ResetData()
+        {
+            // Pause simulation on game load and reset cached speed and pause states
+            SpeedPauseHelper.ResetSpeedAndPauseState();
+            
+            // Reset waiting id as the last speed/pause request is no longer valid
+            SpeedPauseResponseHandler.ResetWaitingId();
+            
+            // Don't handle dropped frames from before the map was loaded
+            SlowdownHelper.ClearDropFrames();
+            SlowdownHelper.ClearLocalDropFrames();
+
+            // TODO: Check if we need to reset more caches
         }
 
         public override void OnLevelUnloading()

--- a/src/Extensions/ThreadingExtension.cs
+++ b/src/Extensions/ThreadingExtension.cs
@@ -9,20 +9,11 @@ namespace CSM.Extensions
 {
     public class ThreadingExtension : ThreadingExtensionBase
     {
-        private int _lastSelectedSimulationSpeed = -1;
-        private bool _lastSimulationPausedState;
         private DateTime _lastEconomyAndDropSync;
 
         public override void OnBeforeSimulationTick()
         {
             base.OnBeforeSimulationTick();
-
-            // Make sure the games stays paused when blocked (e.g. when another player is joining)
-            if (_lastSimulationPausedState != SimulationManager.instance.SimulationPaused
-                && MultiplayerManager.Instance.GameBlocked)
-            {
-                SimulationManager.instance.SimulationPaused = true;
-            }
             
             // Normally, the game is paused when the player is in Esc or similar menus. We ignore this setting.
             if (SimulationManager.instance.ForcedSimulationPaused && MultiplayerManager.Instance.CurrentRole != MultiplayerRole.None)
@@ -30,42 +21,25 @@ namespace CSM.Extensions
                 SimulationManager.instance.ForcedSimulationPaused = false;
             }
 
-            // First tick in the game, initialize speed and pause state tracking variables
-            if (_lastSelectedSimulationSpeed == -1)
-            {
-                _lastSelectedSimulationSpeed = SimulationManager.instance.SelectedSimulationSpeed;
-                _lastSimulationPausedState = SimulationManager.instance.SimulationPaused;
-                SpeedPauseHelper.Initialize(_lastSimulationPausedState, _lastSelectedSimulationSpeed);
-            }
+            // Process changes in the pause state and game speed
+            SpeedPauseHelper.SimulationStep();
 
-            // Check if speed or pause state have changed
-            if (_lastSelectedSimulationSpeed != SimulationManager.instance.SelectedSimulationSpeed ||
-                _lastSimulationPausedState != SimulationManager.instance.SimulationPaused)
-            {
-                SpeedPauseHelper.PlayPauseSpeedChanged(SimulationManager.instance.SimulationPaused,
-                    SimulationManager.instance.SelectedSimulationSpeed);
-
-                // Temporarily reset to old value while waiting for a changed state
-                SimulationManager.instance.SimulationPaused = _lastSimulationPausedState;
-                SimulationManager.instance.SelectedSimulationSpeed = _lastSelectedSimulationSpeed;
-            }
-
-            // Update play/pause state if needed
-            SpeedPauseHelper.ChangePauseStateIfNeeded();
-
-            _lastSimulationPausedState = SimulationManager.instance.SimulationPaused;
-            _lastSelectedSimulationSpeed = SimulationManager.instance.SelectedSimulationSpeed;
-
+            // Process events of the network lib
             MultiplayerManager.Instance.ProcessEvents();
         }
 
         public override void OnAfterSimulationTick()
         {
-            // Send economy packets every two seconds
+            // Send economy and frame drop packets every two seconds
             if (DateTime.Now.Subtract(_lastEconomyAndDropSync).TotalSeconds > 2)
             {
-                ResourceCommandHandler.Send();
-                SlowdownHelper.SendDroppedFrames();
+                // Only send economy and dropped frames when connected
+                // (loading may accumulate dropped frames we need to ignore)
+                if (MultiplayerManager.Instance.IsConnected())
+                {
+                    ResourceCommandHandler.Send();
+                    SlowdownHelper.SendDroppedFrames();
+                }
                 _lastEconomyAndDropSync = DateTime.Now;
             }
 

--- a/src/Helpers/SlowdownHelper.cs
+++ b/src/Helpers/SlowdownHelper.cs
@@ -86,6 +86,17 @@ namespace CSM.Helpers
         }
 
         /// <summary>
+        ///     Clears all locally collected dropped frames so they are never send out.
+        /// </summary>
+        public static void ClearLocalDropFrames()
+        {
+            lock (_localDropLock)
+            {
+                _locallyDroppedFrames = 0;
+            }
+        }
+
+        /// <summary>
         ///     Checks if a frame needs to be dropped.
         ///     Every _dropInterval a frame is dropped.
         /// </summary>

--- a/src/Helpers/SpeedPauseHelper.cs
+++ b/src/Helpers/SpeedPauseHelper.cs
@@ -3,8 +3,10 @@ using System.Linq;
 using CSM.Commands;
 using CSM.Commands.Data.Game;
 using CSM.Commands.Handler.Game;
+using CSM.Commands.Handler.Internal;
 using CSM.Networking;
 using CSM.Networking.Status;
+using CSM.Panels;
 using CSM.Util;
 using UnityEngine;
 
@@ -13,19 +15,125 @@ namespace CSM.Helpers
     public static class SpeedPauseHelper
     {
         private static System.Random _rand;
-        
+
+        // Current state of the state machine
         private static SpeedPauseState _state;
+        // Currently queued speed
         private static int _speed;
         
         // Target time during WaitingForPlay or WaitingForPause states representing real-time and in game time respectively
         private static DateTime _waitTargetTime;
+
+
+        // Target values if one of the buttons was pressed by the player
+        public static bool? PauseTarget = null;
+        public static int? SpeedTarget = null;
+        
+        // If the state machine was already initialized
+        private static bool _initialized = false;
+
+        /// <summary>
+        ///     Resets the speed and pause states and re-initializes the state machine.
+        /// </summary>
+        public static void ResetSpeedAndPauseState()
+        {
+            _initialized = false;
+            SetSpeedStateInternal(1);
+            SetPauseStateInternal(true);
+        }
+
+        /// <summary>
+        ///     Checks if the current play/pause state is stable, e.g. for the /sync command.
+        /// </summary>
+        /// <returns>If the state is either paused or playing but not in any kind of waiting state.</returns>
+        public static bool IsStable()
+        {
+            return _state == SpeedPauseState.Paused || _state == SpeedPauseState.Playing;
+        }
+
+        /// <summary>
+        ///     Called every simulation step to check for any changed speed or pause states.
+        /// </summary>
+        public static void SimulationStep()
+        {
+            // First tick in the game, initialize speed and pause state tracking variables
+            if (!_initialized)
+            {
+                Initialize(SimulationManager.instance.SimulationPaused, SimulationManager.instance.SelectedSimulationSpeed);
+                _initialized = true;
+            }
+
+            // Stores if a speed or pause state negotiation is allowed to start or if a changed state should be ignored
+            bool allowNegotiation = false;
+
+            // If game is blocked or client is connecting
+            if (MultiplayerManager.Instance.GameBlocked ||
+               (MultiplayerManager.Instance.CurrentRole == MultiplayerRole.Client && 
+                MultiplayerManager.Instance.CurrentClient.Status != ClientStatus.Connected))
+            {
+                // Pause the game if it is not yet paused (on the server) and thus trigger the pause negotiation (PauseRequest)
+                if (!SimulationManager.instance.SimulationPaused &&
+                    MultiplayerManager.Instance.CurrentRole == MultiplayerRole.Server)
+                {
+                    SimulationManager.instance.SimulationPaused = true;
+                    allowNegotiation = true;
+                }
+                // Pause the game if it is not yet paused (on the joining/syncing client) but don't trigger a negotiation
+                else if (!SimulationManager.instance.SimulationPaused &&
+                         MultiplayerManager.Instance.CurrentClient.Status != ClientStatus.Connected)
+                {
+                    SetSpeedStateInternal(1);
+                    SetPauseStateInternal(true);
+                }
+            }
+            else
+            {
+                allowNegotiation = true;
+            }
+
+            if (allowNegotiation)
+            {
+                // Check if speed or pause state have changed
+                if ((SpeedTarget.HasValue && SpeedTarget.Value != SimulationManager.instance.SelectedSimulationSpeed) ||
+                    (PauseTarget.HasValue && PauseTarget != SimulationManager.instance.SimulationPaused))
+                {
+                    PlayPauseSpeedChanged(PauseTarget ?? SimulationManager.instance.SimulationPaused,
+                        SpeedTarget ?? SimulationManager.instance.SelectedSimulationSpeed);
+                }
+            }
+
+            // Reset changes in speed or pause state because we don't want to consider them in a later tick
+            SpeedTarget = null;
+            PauseTarget = null;
+
+            // Update play/pause state if needed
+            ChangePauseStateIfNeeded();
+        }
+
+        /// <summary>
+        ///     Sets the internal pause state without triggering a negotiation by calling the setter.
+        /// </summary>
+        /// <param name="paused">If the game should be paused.</param>
+        private static void SetPauseStateInternal(bool paused)
+        {
+            ReflectionHelper.SetAttr(SimulationManager.instance, "m_simulationPaused", paused);
+        }
+
+        /// <summary>
+        ///     Sets the internal speed without triggering a negotiation by calling the setter.
+        /// </summary>
+        /// <param name="speed">The game speed to set.</param>
+        private static void SetSpeedStateInternal(int speed)
+        {
+            ReflectionHelper.SetAttr(SimulationManager.instance, "m_simulationSpeed", speed);
+        }
 
         /// <summary>
         ///     Initialize current speed and pause states.
         /// </summary>
         /// <param name="paused">If the game is currently paused.</param>
         /// <param name="speed">Current game speed from 0 to 3.</param>
-        public static void Initialize(bool paused, int speed)
+        private static void Initialize(bool paused, int speed)
         {
             _state = paused ? SpeedPauseState.Paused : SpeedPauseState.Playing;
             _speed = speed;
@@ -38,7 +146,7 @@ namespace CSM.Helpers
         /// </summary>
         /// <param name="pause">If the game should be paused.</param>
         /// <param name="speed">The newly selected speed.</param>
-        public static void PlayPauseSpeedChanged(bool pause, int speed)
+        private static void PlayPauseSpeedChanged(bool pause, int speed)
         {
             if (_state == SpeedPauseState.Paused && !pause)
             {
@@ -54,6 +162,11 @@ namespace CSM.Helpers
             {
                 RequestSpeedChange(speed);
                 Log.Debug("[SpeedPauseHelper] Speed change requested locally.");
+            }
+            else
+            {
+                ChatLogPanel.PrintGameMessage("Please wait until all players have reached the same play/pause state and speed!");
+                Log.Info($"[SpeedPauseHelper] (Pause: {pause}, Speed: {speed}) requested, but state was {_state}");
             }
         }
 
@@ -125,11 +238,11 @@ namespace CSM.Helpers
         /// <summary>
         ///     This method is called every tick and checks if the waitTargetTime has already been reached.
         /// </summary>
-        public static void ChangePauseStateIfNeeded()
+        private static void ChangePauseStateIfNeeded()
         {
             if (_state == SpeedPauseState.WaitingForPause && GetCurrentTime() > _waitTargetTime)
             {
-                SimulationManager.instance.SimulationPaused = true;
+                SetPauseStateInternal(true);
                 _state = SpeedPauseState.PausedWaiting;
                 SendReached();
 
@@ -138,7 +251,7 @@ namespace CSM.Helpers
             }
             else if (_state == SpeedPauseState.WaitingForSpeedChange && GetCurrentTime() > _waitTargetTime)
             {
-                SimulationManager.instance.SelectedSimulationSpeed = _speed;
+                SetSpeedStateInternal(_speed);
                 _state = SpeedPauseState.PlayingWaiting;
                 SendReached();
                 
@@ -148,8 +261,8 @@ namespace CSM.Helpers
             }
             else if (_state == SpeedPauseState.WaitingForPlay && DateTime.Now >= _waitTargetTime)
             {
-                SimulationManager.instance.SimulationPaused = false;
-                SimulationManager.instance.SelectedSimulationSpeed = _speed;
+                SetPauseStateInternal(false);
+                SetSpeedStateInternal(_speed);
                 _state = SpeedPauseState.PlayingWaiting;
                 SendReached();
 
@@ -171,6 +284,12 @@ namespace CSM.Helpers
             else if (_state == SpeedPauseState.PausedWaiting)
             {
                 _state = SpeedPauseState.Paused;
+                
+                // If a connection request is pending, we complete it here, since now all games are paused.
+                if (ConnectionRequestHandler.WorldLoadingPlayer != null)
+                {
+                    ConnectionRequestHandler.AllGamesBlocked();
+                }
             }
 
             Log.Debug($"[SpeedPauseHelper] State {_state} reached!");

--- a/src/Helpers/SpeedPauseHelper.cs
+++ b/src/Helpers/SpeedPauseHelper.cs
@@ -75,8 +75,12 @@ namespace CSM.Helpers
                 if (!SimulationManager.instance.SimulationPaused &&
                     MultiplayerManager.Instance.CurrentRole == MultiplayerRole.Server)
                 {
-                    SimulationManager.instance.SimulationPaused = true;
-                    allowNegotiation = true;
+                    // Only request pause when the state is stable (so no warning message is shown to the user)
+                    if (IsStable())
+                    {
+                        PauseTarget = true;
+                        allowNegotiation = true;
+                    }
                 }
                 // Pause the game if it is not yet paused (on the joining/syncing client) but don't trigger a negotiation
                 else if (!SimulationManager.instance.SimulationPaused &&

--- a/src/Injections/SpeedPauseHandler.cs
+++ b/src/Injections/SpeedPauseHandler.cs
@@ -6,13 +6,6 @@ namespace CSM.Injections
 {
     // Prevent both the SimulationPaused and SelectedSimulationSpeed setters from running and save the target value
     // for processing.
-    // Note that these setters can be called in a different thread (ui thread) than the simulation is running in.
-    // This means that the PauseTarget and SpeedTarget variables are written and read in different threads respectively.
-    // This is not a problem because we only set the values in the ui thread, but always reset them back to null
-    // in the same thread they are read (simulation thread).
-    // In the worst case, the value is set after the null check in SpeedPauseHelper::SimulationStep was performed,
-    // which means that it is not considered and reset back to null.
-    // This does not cause a problem, but only requires the user to press the button again.
 
     [HarmonyPatch(typeof(SimulationManager))]
     [HarmonyPatch("SimulationPaused", MethodType.Setter)]

--- a/src/Injections/SpeedPauseHandler.cs
+++ b/src/Injections/SpeedPauseHandler.cs
@@ -1,0 +1,46 @@
+using ColossalFramework;
+using CSM.Helpers;
+using HarmonyLib;
+
+namespace CSM.Injections
+{
+    // Prevent both the SimulationPaused and SelectedSimulationSpeed setters from running and save the target value
+    // for processing.
+    // Note that these setters can be called in a different thread (ui thread) than the simulation is running in.
+    // This means that the PauseTarget and SpeedTarget variables are written and read in different threads respectively.
+    // This is not a problem because we only set the values in the ui thread, but always reset them back to null
+    // in the same thread they are read (simulation thread).
+    // In the worst case, the value is set after the null check in SpeedPauseHelper::SimulationStep was performed,
+    // which means that it is not considered and reset back to null.
+    // This does not cause a problem, but only requires the user to press the button again.
+
+    [HarmonyPatch(typeof(SimulationManager))]
+    [HarmonyPatch("SimulationPaused", MethodType.Setter)]
+    public static class SetSimulationPaused
+    {
+        public static bool Prefix(bool value)
+        {
+            SpeedPauseHelper.PauseTarget = value;
+
+            // Don't run the original method
+            return false;
+        }
+    }
+    
+    [HarmonyPatch(typeof(SimulationManager))]
+    [HarmonyPatch("SelectedSimulationSpeed", MethodType.Setter)]
+    public class SetSelectedSimulationSpeed
+    {
+        public static bool Prefix(int value)
+        {
+            SpeedPauseHelper.SpeedTarget = value;
+            if (SimulationManager.instance.SimulationPaused)
+            {
+                SpeedPauseHelper.PauseTarget = false;
+            }
+
+            // Don't run the original method
+            return false;
+        }
+    }
+}

--- a/src/Networking/MultiplayerManager.cs
+++ b/src/Networking/MultiplayerManager.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using CSM.Networking.Status;
 
 namespace CSM.Networking
 {
@@ -126,6 +127,12 @@ namespace CSM.Networking
                     break;
             }
             CurrentRole = MultiplayerRole.None;
+        }
+
+        public bool IsConnected()
+        {
+            return CurrentRole == MultiplayerRole.Server || (CurrentRole == MultiplayerRole.Client &&
+                                                             CurrentClient.Status == ClientStatus.Connected);
         }
 
         public void BlockGameReSync()

--- a/src/Panels/ChatLogPanel.cs
+++ b/src/Panels/ChatLogPanel.cs
@@ -95,13 +95,20 @@ namespace CSM.Panels
                 {
                     if (MultiplayerManager.Instance.CurrentRole == MultiplayerRole.Client)
                     {
-                        PrintGameMessage("Requesting the save game from the server");
+                        if (MultiplayerManager.Instance.GameBlocked)
+                        {
+                            PrintGameMessage("Please wait until the currently joining player is connected!");
+                        }
+                        else
+                        {
+                            PrintGameMessage("Requesting the save game from the server");
 
-                        MultiplayerManager.Instance.CurrentClient.Status = Networking.Status.ClientStatus.Downloading;
-                        SimulationManager.instance.SimulationPaused = true;
-                        MultiplayerManager.Instance.BlockGameReSync();
+                            MultiplayerManager.Instance.CurrentClient.Status =
+                                Networking.Status.ClientStatus.Downloading;
+                            MultiplayerManager.Instance.BlockGameReSync();
 
-                        Command.SendToServer(new RequestWorldTransferCommand());
+                            Command.SendToServer(new RequestWorldTransferCommand());
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
- Block speed and pause state changes by default and only allow them explicitly
- Negotiate pause state before re-syncing the game
- Move all speed and pause state logic to the SpeedPauseHelper
- Force state to paused on game load (ignore the user setting)

Hopefully fixes #226 