### PR TITLE
Fix #169: Use the Screen dimensions for window placement

### DIFF
--- a/src/Panels/ClientJoinPanel.cs
+++ b/src/Panels/ClientJoinPanel.cs
@@ -25,19 +25,16 @@ namespace CSM.Panels
             name = "ClientJoinPanel";
             color = new Color32(110, 110, 110, 220);
 
-            // Grab the view for calculating width and height of game
-            UIView view = UIView.GetAView();
-
             relativePosition = new Vector3(0, 0);
 
-            width = view.fixedWidth;
-            height = view.fixedHeight;
+            width = Screen.width;
+            height = Screen.height;
 
             // Connecting Status
             _statusLabel = this.CreateTitleLabel("", new Vector2(0, 0));
 
             // Canel button only while first join
-            _cancelButton = this.CreateButton("Cancel", new Vector2((width / 2f) - 170f, -(height / 2f) - 60f));
+            _cancelButton = this.CreateButton("Cancel", new Vector2((Screen.width / 2f) - 170f, -(Screen.height / 2f) - 60f));
             _cancelButton.eventClick += OnCancelButtonClick;
             _cancelButton.isVisible = false;
         }

--- a/src/Panels/ConnectedPlayersPanel.cs
+++ b/src/Panels/ConnectedPlayersPanel.cs
@@ -27,11 +27,8 @@ namespace CSM.Panels
             backgroundSprite = "GenericPanel";
             color = new Color32(110, 110, 110, 250);
 
-            // Grab the view for calculating width and height of game
-            UIView view = UIView.GetAView();
-
             // Center this window in the game
-            relativePosition = new Vector3(view.fixedWidth / 2.0f - 180.0f, view.fixedHeight / 2.0f - 240.0f);
+            relativePosition = new Vector3(Screen.width / 2.0f - 180.0f, Screen.height / 2.0f - 240.0f);
 
             width = 360;
             height = 445;

--- a/src/Panels/ConnectionPanel.cs
+++ b/src/Panels/ConnectionPanel.cs
@@ -24,11 +24,8 @@ namespace CSM.Panels
             backgroundSprite = "GenericPanel";
             color = new Color32(110, 110, 110, 250);
 
-            // Grab the view for calculating width and height of game
-            UIView view = UIView.GetAView();
-
             // Center this window in the game
-            relativePosition = new Vector3(view.fixedWidth / 2.0f - 180.0f, view.fixedHeight / 2.0f - 100.0f);
+            relativePosition = new Vector3(Screen.width / 2.0f - 180.0f, Screen.height / 2.0f - 100.0f);
 
             width = 360;
             height = 320;

--- a/src/Panels/HostGamePanel.cs
+++ b/src/Panels/HostGamePanel.cs
@@ -43,7 +43,7 @@ namespace CSM.Panels
             UIView view = UIView.GetAView();
 
             // Center this window in the game
-            relativePosition = new Vector3(view.fixedWidth / 2.0f - 180.0f, view.fixedHeight / 2.0f - 250.0f);
+            relativePosition = new Vector3(Screen.width / 2.0f - 180.0f, Screen.height / 2.0f - 250.0f);
 
             width = 360;
             height = 580;

--- a/src/Panels/JoinGamePanel.cs
+++ b/src/Panels/JoinGamePanel.cs
@@ -38,11 +38,8 @@ namespace CSM.Panels
             backgroundSprite = "GenericPanel";
             color = new Color32(110, 110, 110, 255);
 
-            // Grab the view for calculating width and height of game
-            UIView view = UIView.GetAView();
-
             // Center this window in the game
-            relativePosition = new Vector3(view.fixedWidth / 2.0f - 180.0f, view.fixedHeight / 2.0f - 250.0f);
+            relativePosition = new Vector3(Screen.width / 2.0f - 180.0f, Screen.height / 2.0f - 250.0f);
 
             width = 360;
             height = 585;

--- a/src/Panels/ManageGamePanel.cs
+++ b/src/Panels/ManageGamePanel.cs
@@ -23,11 +23,8 @@ namespace CSM.Panels
             backgroundSprite = "GenericPanel";
             color = new Color32(110, 110, 110, 250);
 
-            // Grab the view for calculating width and height of game
-            UIView view = UIView.GetAView();
-
             // Center this window in the game
-            relativePosition = new Vector3(view.fixedWidth / 2.0f - 180.0f, view.fixedHeight / 2.0f - 240.0f);
+            relativePosition = new Vector3(Screen.width / 2.0f - 180.0f, Screen.height / 2.0f - 240.0f);
 
             width = 360;
             height = 445;

--- a/src/Panels/MessagePanel.cs
+++ b/src/Panels/MessagePanel.cs
@@ -26,11 +26,8 @@ namespace CSM.Panels
             backgroundSprite = "GenericPanel";
             color = new Color32(110, 110, 110, 255);
 
-            // Grab the view for calculating width and height of game
-            UIView view = UIView.GetAView();
-
             // Center this window in the game
-            relativePosition = new Vector3(view.fixedWidth / 2.0f - 225.0f, view.fixedHeight / 2.0f - 200.0f);
+            relativePosition = new Vector3(Screen.width / 2.0f - 225.0f, Screen.height / 2.0f - 200.0f);
 
             width = 450;
             height = 500;


### PR DESCRIPTION
Cities: Skylines does not natively support aspect ratios other than 4:3, 16:9 and 16:10 for whatever reason. This is the reason mods like [More Aspect Ratios](https://steamcommunity.com/sharedfiles/filedetails/?id=561218257) exist and are required for many players on these "special" screen resolutions. So as the UIView does not give us the proper screen dimensions, we should use UnityEngine's Screen to properly center and size the panels. These windows are supposed to be centered anyway and the ClientJoinPanel should cover the *entire screen*.
To add to #169, you can actually continue "playing" through the empty gaps at the right side when using anything wider than 16:9, which resulted in some clients not being able to properly download the savegame.