### PR TITLE
Fix compilation/patching issues from the airport update

### DIFF
--- a/src/Commands/Data/TransportLines/TransportLineChangeVehicleCommand.cs
+++ b/src/Commands/Data/TransportLines/TransportLineChangeVehicleCommand.cs
@@ -20,6 +20,6 @@ namespace CSM.Commands.Data.TransportLines
         ///     The prefab info index of the new vehicle.
         /// </summary>
         [ProtoMember(2)]
-        public uint Vehicle;
+        public uint? Vehicle;
     }
 }

--- a/src/Commands/Handler/TransportLines/TransportLineChangeVehicleHandler.cs
+++ b/src/Commands/Handler/TransportLines/TransportLineChangeVehicleHandler.cs
@@ -11,7 +11,11 @@ namespace CSM.Commands.Handler.TransportLines
 
             // Use ref because otherwise the TransportLine struct(!) would be copied
             ref TransportLine line = ref TransportManager.instance.m_lines.m_buffer[command.LineId];
-            VehicleInfo vehicle = PrefabCollection<VehicleInfo>.GetPrefab(command.Vehicle);
+
+            VehicleInfo vehicle = null;
+            if (command.Vehicle.HasValue) {
+                vehicle = PrefabCollection<VehicleInfo>.GetPrefab(command.Vehicle.Value);
+            }
 
             ReflectionHelper.Call(line, "ReplaceVehicles", command.LineId, vehicle);
 

--- a/src/Helpers/DLCHelper.cs
+++ b/src/Helpers/DLCHelper.cs
@@ -6,9 +6,9 @@ namespace CSM.Helpers
                                                               SteamHelper.DLC_BitMask.RadioStation2 |
                                                               SteamHelper.DLC_BitMask.RadioStation3 |
                                                               SteamHelper.DLC_BitMask.RadioStation4 |
-                                                              SteamHelper.DLC_BitMask.RadioStation5 |
-                                                              SteamHelper.DLC_BitMask.RadioStation6 |
-                                                              SteamHelper.DLC_BitMask.RadioStation7;
+                                                              SteamHelper.DLC_BitMask.RadioStation5;
+                                                              // Only need to check 1 - 5 as others are
+                                                              // in BitMask2 which we ignore completely.
 
         private static SteamHelper.DLC_BitMask RemoveRadioStations(SteamHelper.DLC_BitMask bitmask)
         {

--- a/src/Injections/TransportHandler.cs
+++ b/src/Injections/TransportHandler.cs
@@ -763,41 +763,19 @@ namespace CSM.Injections
     [HarmonyPatch("ReplaceVehicles")]
     public class ReplaceVehicles
     {
-        public static VehicleInfo randomGen = null;
-
-        public static void Prefix()
-        {
-            randomGen = null;
-        }
-
         public static void Postfix(ushort lineID, VehicleInfo info)
         {
             if (IgnoreHelper.IsIgnored())
                 return;
 
-            if (info == null)
-            {
-                if (randomGen == null)
-                    return;
-
-                info = randomGen;
-            }
+            // TODO: When info is null, random vehicle gets generated on spawn
+            // To be in sync, we need to sync the randomization!
 
             Command.SendToAll(new TransportLineChangeVehicleCommand()
             {
                 LineId = lineID,
                 Vehicle = (uint)info.m_prefabDataIndex
             });
-        }
-    }
-
-    [HarmonyPatch(typeof(TransportLine))]
-    [HarmonyPatch("GetRandomVehicleInfo")]
-    public class GetRandomVehicleInfo
-    {
-        public static void Postfix(VehicleInfo __result)
-        {
-            ReplaceVehicles.randomGen = __result;
         }
     }
 }

--- a/src/Panels/MessagePanel.cs
+++ b/src/Panels/MessagePanel.cs
@@ -129,18 +129,11 @@ namespace CSM.Panels
             Version version = Assembly.GetAssembly(typeof(CSM)).GetName().Version;
 
             string message = $"Version {version.Major}.{version.Minor}\n" +
-                             $"Last Update: April 4, 2021\n\n" +
-                             "- UI Changes:\n" +
-                             "  - The Chirper is now used as the chat\n" +
-                             "    (The old chat can still be enabled in the settings)\n" +
-                             "  - The multiplayer menu can now be found\n" +
-                             "    in the pause menu\n" +
-                             "  - Added this release notes panel\n\n" +
+                             $"Last Update: January 28th, 2022\n\n" +
                              "- Fixes:\n" +
-                             "  - Tried to fix issue with not being able to change\n" +
-                             "    the speed or pause state (Please tell us on Discord\n" +
-                             "    if the problems are now solved for you!).\n";
-
+                             "  - Support Airports Update. Note\n" +
+                             "    that not all new features are" +
+                             "    supported for now!\n";
             SetMessage(message);
 
             Show(true);


### PR DESCRIPTION
This should make the game playable again with the airport update.

Although note that neither the new free content (changing the trees for streets with trees) nor the DLC content (airports) will be fully synced.

This also introduces another TODO, random service vehicles no longer synchronize their current vehicle type which already worked previously. This needs some extended work.