### PR TITLE
Add port checking

### DIFF
--- a/src/api/CSM.API.csproj
+++ b/src/api/CSM.API.csproj
@@ -58,10 +58,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="LiteNetLib">
-      <Version>0.9.2.2</Version>
+      <Version>0.9.4</Version>
     </PackageReference>
     <PackageReference Include="protobuf-net">
-      <Version>2.4.6</Version>
+      <Version>2.4.7</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/basegame/CSM.BaseGame.csproj
+++ b/src/basegame/CSM.BaseGame.csproj
@@ -229,10 +229,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="LiteNetLib">
-      <Version>0.9.2.2</Version>
+      <Version>0.9.4</Version>
     </PackageReference>
     <PackageReference Include="CitiesHarmony.API">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/csm/CSM.cs
+++ b/src/csm/CSM.cs
@@ -43,7 +43,7 @@ namespace CSM
                 // Registers all other mods which implement the API
                 ModSupport.Instance.Init();
                 // Setup join button
-                MainMenuHandler.CreateOrUpdateJoinGameButton();
+                MainMenuHandler.Init();
 
                 Log.Info("Construction Complete!");
             });

--- a/src/csm/CSM.csproj
+++ b/src/csm/CSM.csproj
@@ -142,20 +142,21 @@
     <Compile Include="Panels\JoinGamePanel.cs" />
     <Compile Include="CSM.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Util\CSMWebClient.cs" />
     <Compile Include="Util\Serializer.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="LiteNetLib">
-      <Version>0.9.2.2</Version>
+      <Version>0.9.4</Version>
     </PackageReference>
     <PackageReference Include="Open.Nat">
       <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="protobuf-net">
-      <Version>2.4.6</Version>
+      <Version>2.4.7</Version>
     </PackageReference>
     <PackageReference Include="CitiesHarmony.API">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/csm/Injections/MainMenuHandler.cs
+++ b/src/csm/Injections/MainMenuHandler.cs
@@ -37,7 +37,7 @@ namespace CSM.Injections
         {
             try
             {
-                string latest = new CSMWebClient().DownloadString("http://csm-check.kaenganxt.dev/api/version");
+                string latest = new CSMWebClient().DownloadString("http://api.citiesskylinesmultiplayer.com/api/version");
                 latest = latest.Substring(1);
                 string[] versionParts = latest.Split('.');
                 Version latestVersion = new Version(int.Parse(versionParts[0]), int.Parse(versionParts[1]));

--- a/src/csm/Injections/MainMenuHandler.cs
+++ b/src/csm/Injections/MainMenuHandler.cs
@@ -1,6 +1,11 @@
-﻿using ColossalFramework.UI;
+﻿using System;
+using System.Reflection;
+using System.Threading;
+using ColossalFramework.Threading;
+using ColossalFramework.UI;
 using CSM.API;
 using CSM.Panels;
+using CSM.Util;
 using HarmonyLib;
 using UnityEngine;
 
@@ -16,13 +21,54 @@ namespace CSM.Injections
         /// </summary>
         public static void Prefix()
         {
-            MainMenuHandler.CreateOrUpdateJoinGameButton();
+            MainMenuHandler.Init();
         }
     }
 
     public static class MainMenuHandler
     {
-        public static void CreateOrUpdateJoinGameButton()
+        public static void Init()
+        {
+            CreateOrUpdateJoinGameButton();
+            new Thread(() => CheckForUpdate(false)).Start();
+        }
+
+        public static void CheckForUpdate(bool alwaysShowInfo)
+        {
+            try
+            {
+                string latest = new CSMWebClient().DownloadString("http://csm-check.kaenganxt.dev/api/version");
+                latest = latest.Substring(1);
+                string[] versionParts = latest.Split('.');
+                Version latestVersion = new Version(int.Parse(versionParts[0]), int.Parse(versionParts[1]));
+
+                Version version = Assembly.GetAssembly(typeof(CSM)).GetName().Version;
+                if (latestVersion > version)
+                {
+                    Log.Info(
+                        $"Update available! Current version: {version.Major}.{version.Minor} Latest version: {latestVersion.Major}.{latestVersion.Minor}");
+                    ThreadHelper.dispatcher.Dispatch(() =>
+                    {
+                        MessagePanel panel = PanelManager.ShowPanel<MessagePanel>();
+                        panel.DisplayUpdateAvailable(version, latestVersion);
+                    });
+                }
+                else if (alwaysShowInfo)
+                {
+                    ThreadHelper.dispatcher.Dispatch(() =>
+                    {
+                        MessagePanel panel = PanelManager.ShowPanel<MessagePanel>();
+                        panel.DisplayNoUpdateAvailable();
+                    });
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Warn($"Failed to check for updates: {e.Message}");
+            }
+        }
+
+        private static void CreateOrUpdateJoinGameButton()
         {
             Log.Info("Creating join game button...");
 

--- a/src/csm/Networking/IpAddress.cs
+++ b/src/csm/Networking/IpAddress.cs
@@ -1,9 +1,26 @@
 ﻿using System;
+using System.IO;
 using System.Net;
 using System.Net.Sockets;
+using System.ServiceModel.Channels;
+using System.Text;
+using CSM.API;
+using CSM.Util;
 
 namespace CSM.Networking
 {
+    public struct PortState
+    {
+        public string message;
+        public HttpStatusCode status;
+
+        public PortState(string message, HttpStatusCode status)
+        {
+            this.message = message;
+            this.status = status;
+        }
+    }
+
     public static class IpAddress
     {
         private static string _localIp;
@@ -22,7 +39,7 @@ namespace CSM.Networking
                 using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, 0))
                 {
                     //Connect to 8.8.8.8 (Google IP)
-                    socket.Connect("8.8.8.8", 65530);
+                    socket.Connect("csm-check.kaenganxt.dev", 65530);
                     //Get the IPEndPoint
                     IPEndPoint endPoint = socket.LocalEndPoint as IPEndPoint;
                     //Get the IP Address (Internal) from the IPEndPoint
@@ -46,14 +63,54 @@ namespace CSM.Networking
 
             try
             {
-                //Get the External IP (IPv4) Address from internet
-                _externalIp = new WebClient().DownloadString("http://api.ipify.org"); // HTTPS doesn't work
+                //Get the External IP address from internet
+                _externalIp = new CSMWebClient().DownloadString("http://csm-check.kaenganxt.dev/api/ip");
                 return _externalIp;
             }
-            catch (Exception)
+            catch (Exception e)
             {
                 //On error return "Not found"
+                Log.Error("Failed to request IP: " + e.Message);
                 return "Not found";
+            }
+        }
+
+        public static PortState CheckPort(int port)
+        {
+            CSMWebClient client = new CSMWebClient();
+            try
+            {
+                string answer = client.DownloadString("http://csm-check.kaenganxt.dev/api/check?port=" + port);
+                return new PortState(answer, client.StatusCode());
+            }
+            catch (WebException e)
+            {
+                if (e.Response is HttpWebResponse response)
+                {
+                    Encoding encoding = response.CharacterSet != null ? Encoding.GetEncoding(response.CharacterSet) : Encoding.ASCII;
+                    using (Stream stream = response.GetResponseStream())
+                    {
+                        if (stream != null)
+                        {
+                            using (StreamReader reader = new StreamReader(stream, encoding))
+                            {
+                                return new PortState(reader.ReadToEnd(), response.StatusCode);
+                            }
+                        }
+                        else
+                        {
+                            return new PortState(e.Message, HttpStatusCode.InternalServerError);
+                        }
+                    }
+                }
+                else
+                {
+                    return new PortState(e.Message, HttpStatusCode.InternalServerError);
+                }
+            }
+            catch (Exception e)
+            {
+                return new PortState(e.Message, HttpStatusCode.InternalServerError);
             }
         }
     }

--- a/src/csm/Networking/IpAddress.cs
+++ b/src/csm/Networking/IpAddress.cs
@@ -37,8 +37,8 @@ namespace CSM.Networking
                 //Create a new socket
                 using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, 0))
                 {
-                    //Connect to 8.8.8.8 (Google IP)
-                    socket.Connect("csm-check.kaenganxt.dev", 65530);
+                    //Connect to some server to non-listening port
+                    socket.Connect("api.citiesskylinesmultiplayer.com", 65530);
                     //Get the IPEndPoint
                     IPEndPoint endPoint = socket.LocalEndPoint as IPEndPoint;
                     //Get the IP Address (Internal) from the IPEndPoint
@@ -63,7 +63,7 @@ namespace CSM.Networking
             try
             {
                 //Get the External IP address from internet
-                _externalIp = new CSMWebClient().DownloadString("http://csm-check.kaenganxt.dev/api/ip");
+                _externalIp = new CSMWebClient().DownloadString("http://api.citiesskylinesmultiplayer.com/api/ip");
                 return _externalIp;
             }
             catch (Exception e)
@@ -79,7 +79,7 @@ namespace CSM.Networking
             CSMWebClient client = new CSMWebClient();
             try
             {
-                string answer = client.DownloadString("http://csm-check.kaenganxt.dev/api/check?port=" + port);
+                string answer = client.DownloadString("http://api.citiesskylinesmultiplayer.com/api/check?port=" + port);
                 return new PortState(answer, client.StatusCode());
             }
             catch (WebException e)

--- a/src/csm/Networking/IpAddress.cs
+++ b/src/csm/Networking/IpAddress.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
-using System.ServiceModel.Channels;
 using System.Text;
 using CSM.API;
 using CSM.Util;

--- a/src/csm/Networking/Server.cs
+++ b/src/csm/Networking/Server.cs
@@ -130,7 +130,7 @@ namespace CSM.Networking
                     if (automaticSuccess)
                     {
                         message =
-                            "Port was forwarded automatically, but server is not reachable from the internet.";
+                            "It was tried to forward the port automatically, but the server is not reachable from the internet. Manual port forwarding is required.";
                     }
                     else
                     {

--- a/src/csm/Panels/ManageGamePanel.cs
+++ b/src/csm/Panels/ManageGamePanel.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 using System.Threading;
 using ColossalFramework;
 using ColossalFramework.UI;
-using CSM.API;
 using CSM.Helpers;
 using CSM.Networking;
-using CSM.Util;
 using UnityEngine;
 
 namespace CSM.Panels

--- a/src/csm/Panels/ManageGamePanel.cs
+++ b/src/csm/Panels/ManageGamePanel.cs
@@ -1,6 +1,12 @@
-﻿using ColossalFramework.UI;
+﻿using System;
+using System.Net;
+using System.Threading;
+using ColossalFramework;
+using ColossalFramework.UI;
+using CSM.API;
 using CSM.Helpers;
 using CSM.Networking;
+using CSM.Util;
 using UnityEngine;
 
 namespace CSM.Panels
@@ -10,10 +16,12 @@ namespace CSM.Panels
         private UITextField _portField;
         private UITextField _localIpField;
         private UITextField _externalIpField;
+        private UILabel _portState;
 
         private UIButton _closeButton;
 
-        private string _portVal, _localIpVal, _externalIpVal;
+        private int _portVal;
+        private string _localIpVal, _externalIpVal;
 
         public override void Start()
         {
@@ -28,18 +36,18 @@ namespace CSM.Panels
             relativePosition = PanelManager.GetCenterPosition(this);
 
             // Title Label
-            UILabel title = this.CreateTitleLabel("Manage Server", new Vector2(100, -20));
+            this.CreateTitleLabel("Manage Server", new Vector2(100, -20));
 
             // Port label
             this.CreateLabel("Port:", new Vector2(10, -75));
 
             // Port field
-            _portVal = MultiplayerManager.Instance.CurrentServer.Config.Port.ToString();
-            _portField = this.CreateTextField(_portVal, new Vector2(10, -100));
+            _portVal = MultiplayerManager.Instance.CurrentServer.Config.Port;
+            _portField = this.CreateTextField(_portVal.ToString(), new Vector2(10, -100));
             _portField.selectOnFocus = true;
             _portField.eventTextChanged += (ui, value) =>
             {
-                _portField.text = _portVal;
+                _portField.text = _portVal.ToString();
             };
 
             // Local IP label
@@ -65,6 +73,9 @@ namespace CSM.Panels
             {
                 _externalIpField.text = _externalIpVal;
             };
+            
+            _portState = this.CreateLabel("", new Vector2(10, -310));
+            _portState.textAlignment = UIHorizontalAlignment.Center;
 
             // Close this dialog
             _closeButton = this.CreateButton("Close", new Vector2(10, -375));
@@ -73,14 +84,50 @@ namespace CSM.Panels
                 isVisible = false;
             };
 
+            new Thread(CheckPort).Start();
+
             eventVisibilityChanged += (component, visible) =>
             {
                 if (!visible)
                     return;
 
-                _portVal = MultiplayerManager.Instance.CurrentServer.Config.Port.ToString();
-                _portField.text = _portVal;
+                _portVal = MultiplayerManager.Instance.CurrentServer.Config.Port;
+                _portField.text = _portVal.ToString();
+                new Thread(CheckPort).Start();
             };
+        }
+
+        private void CheckPort()
+        {
+            Singleton<SimulationManager>.instance.m_ThreadingWrapper.QueueMainThread(() =>
+            {
+                _portState.text = "Checking port...";
+                _portState.textColor = new Color32(255, 255, 0, 255);
+                _portState.tooltip = "Checking if port is reachable from the internet...";
+            });
+
+            PortState state = IpAddress.CheckPort(_portVal);
+            Singleton<SimulationManager>.instance.m_ThreadingWrapper.QueueMainThread(() =>
+            {
+                switch (state.status)
+                {
+                    case HttpStatusCode.ServiceUnavailable: // Could not reach port
+                        _portState.text = "Port is not reachable!";
+                        _portState.textColor = new Color32(255, 0, 0, 255);
+                        _portState.tooltip = state.message;
+                        break;
+                    case HttpStatusCode.OK: // Success
+                        _portState.text = "Port is reachable!";
+                        _portState.textColor = new Color32(0, 255, 0, 255);
+                        _portState.tooltip = "";
+                        break;
+                    default: // Something failed
+                        _portState.text = "Failed to check port";
+                        _portState.textColor = new Color32(255, 0, 0, 255);
+                        _portState.tooltip = state.message;
+                        break;
+                }
+            });
         }
     }
 }

--- a/src/csm/Panels/MessagePanel.cs
+++ b/src/csm/Panels/MessagePanel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using ColossalFramework.UI;
@@ -16,7 +17,8 @@ namespace CSM.Panels
         private string _title;
         private string _message;
 
-        private UIButton _closeButton;
+        private UIButton _closeButton, _githubButton;
+        private bool _githubShown = false;
 
         public override void Start()
         {
@@ -47,6 +49,14 @@ namespace CSM.Panels
 
             this.AddScrollbar(messagePanel);
 
+            // Github button
+            _githubButton = this.CreateButton("Open GitHub", new Vector2(60, -340));
+            _githubButton.eventClicked += (c, p) =>
+            {
+                Process.Start("https://github.com/CitiesSkylinesMultiplayer/CSM/releases");
+            };
+            _githubButton.isVisible = _githubShown;
+
             // Close button
             _closeButton = this.CreateButton("Close", new Vector2(60, -410));
 
@@ -72,6 +82,9 @@ namespace CSM.Panels
 
             if (_messageLabel)
                 _messageLabel.text = message;
+
+            if (_githubButton)
+                _githubButton.Hide();
         }
 
         public void DisplayContentWarning()
@@ -169,6 +182,40 @@ namespace CSM.Panels
                              "  - Support Airports Update. Note\n" +
                              "    that not all new features are" +
                              "    supported for now!\n";
+            SetMessage(message);
+
+            Show(true);
+        }
+
+        public void DisplayUpdateAvailable(Version current, Version latest)
+        {
+            SetTitle("CSM Update available!");
+
+            string message = "A new update of the Cities: Skylines Multiplayer\n" +
+                             "mod is available!\n\n" +
+                             $"Current Version: {current.Major}.{current.Minor}\n" +
+                             $"Latest Version: {latest.Major}.{latest.Minor}\n\n" +
+                             "When using the Steam Workshop, it should be\n" +
+                             "installed automatically (you may need to restart\n" +
+                             "your game). Otherwise you can download the\n" +
+                             "update from GitHub:\n\n" +
+                             "https://github.com/CitiesSkylinesMultiplayer/\n" +
+                             "CSM/releases";
+            SetMessage(message);
+
+            _githubShown = true;
+            if (_githubButton)
+                _githubButton.Show();
+
+            Show(true);
+        }
+
+        public void DisplayNoUpdateAvailable()
+        {
+            SetTitle("CSM is up to date");
+
+            string message = "There is no update for the Cities: Skylines\n" +
+                             "Multiplayer mod available.";
             SetMessage(message);
 
             Show(true);

--- a/src/csm/Panels/SettingsPanel.cs
+++ b/src/csm/Panels/SettingsPanel.cs
@@ -1,5 +1,7 @@
-﻿using ColossalFramework.UI;
+﻿using System.Threading;
+using ColossalFramework.UI;
 using CSM.API;
+using CSM.Injections;
 using CSM.Mods;
 using ICities;
 
@@ -37,6 +39,11 @@ namespace CSM.Panels
             {
                 MessagePanel panel = PanelManager.ShowPanel<MessagePanel>();
                 panel.DisplayReleaseNotes();
+            });
+
+            advancedGroup.AddButton("Check for updates", () =>
+            {
+                new Thread(() => MainMenuHandler.CheckForUpdate(true)).Start();
             });
         }
     }

--- a/src/csm/Util/CSMWebClient.cs
+++ b/src/csm/Util/CSMWebClient.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Net;
+
+namespace CSM.Util
+{
+    class CSMWebClient : WebClient
+    {
+        private WebRequest _request = null;
+
+        protected override WebRequest GetWebRequest(Uri address)
+        {
+            this._request = base.GetWebRequest(address);
+            // Force IPv4 for now, TODO: Remove when CSM supports IPv6
+            if (this._request is HttpWebRequest webRequest)
+            {
+                webRequest.ServicePoint.BindIPEndPointDelegate = (servicePoint, remoteEndPoint, retryCount) =>
+                {
+                    if (remoteEndPoint.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
+                    {
+                        return new IPEndPoint(IPAddress.Any, 0);
+                    }
+
+                    throw new InvalidOperationException("no IPv4 address");
+                };
+
+                webRequest.AllowAutoRedirect = false;
+            }
+
+            return this._request;
+        }
+
+        public HttpStatusCode StatusCode()
+        {
+            HttpStatusCode result;
+
+            if (this._request == null)
+            {
+                throw (new InvalidOperationException("Unable to retrieve the status code, maybe you haven't made a request yet."));
+            }
+
+            if (base.GetWebResponse(this._request) is HttpWebResponse response)
+            {
+                result = response.StatusCode;
+            }
+            else
+            {
+                throw (new InvalidOperationException("Unable to retrieve the status code, maybe you haven't made a request yet."));
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds the ability to check if the CSM server is reachable from the outside.
When starting the CSM server, a check request is sent to a server hosted by me to check for the open port. The result is displayed in the chat.
To check the status again, use the Multiplayer Menu -> Manage Server menu.

The server implementation can be found at [https://github.com/CitiesSkylinesMultiplayer/CSMChecker](https://github.com/CitiesSkylinesMultiplayer/CSMChecker), which is currently running at [https://csm-check.kaenganxt.dev](https://csm-check.kaenganxt.dev).

Some dependencies were also updated.