### PR TITLE
Remove wrapper to UnloadLevel call to fix crash

### DIFF
--- a/src/csm/Networking/Client.cs
+++ b/src/csm/Networking/Client.cs
@@ -187,11 +187,8 @@ namespace CSM.Networking
 
             if (needsUnload)
             {
-                Singleton<SimulationManager>.instance.m_ThreadingWrapper.QueueMainThread(() =>
-                {
-                    // Go back to the main menu after disconnecting
-                    Singleton<LoadingManager>.instance.UnloadLevel();
-                });
+                // Go back to the main menu after disconnecting
+                Singleton<LoadingManager>.instance.UnloadLevel();
             }
 
             Log.Info("Disconnected from server");


### PR DESCRIPTION
Fixes #291 

This assumes that there is no case where the call will occur off the main thread -- if so, the existing call could be wrapped in a try/catch to isolate this fix.