### PR TITLE
Add connection troubleshooting information and add Hamachi detection

### DIFF
--- a/src/csm/Networking/Client.cs
+++ b/src/csm/Networking/Client.cs
@@ -55,6 +55,12 @@ namespace CSM.Networking
         /// </summary>
         public string ConnectionMessage { get; set; } = "Unknown error";
 
+        /// <summary>
+        ///     If the join game panel should show connection troubleshooting
+        ///     information.
+        /// </summary>
+        public bool ShowTroubleshooting { get; set; } = false;
+
         private bool MainMenuEventProcessing = false;
 
         public Client()
@@ -78,6 +84,7 @@ namespace CSM.Networking
         /// <returns>True if the client is connected to the server, false if not</returns>
         public bool Connect(ClientConfig clientConfig)
         {
+            ShowTroubleshooting = false;
             // Let the user know that we are trying to connect to a server
             Log.Info($"Attempting to connect to server at {clientConfig.HostAddress}:{clientConfig.Port}...");
 
@@ -123,6 +130,7 @@ namespace CSM.Networking
             catch (Exception ex)
             {
                 ConnectionMessage = "Failed to connect.";
+                ShowTroubleshooting = true;
                 Log.Error($"Failed to connect to {Config.HostAddress}:{Config.Port}", ex);
                 Chat.Instance.PrintGameMessage(Chat.MessageType.Error, $"Failed to connect: {ex.Message}");
                 Disconnect();
@@ -268,7 +276,10 @@ namespace CSM.Networking
         private void ListenerOnPeerDisconnectedEvent(NetPeer peer, DisconnectInfo disconnectInfo)
         {
             if (Status == ClientStatus.Connecting)
+            {
                 ConnectionMessage = "Failed to connect!";
+                ShowTroubleshooting = true;
+            }
 
             // Log the error message
             Log.Info($"Disconnected from server. Message: {disconnectInfo.Reason}, Code: {disconnectInfo.SocketErrorCode}");

--- a/src/csm/Networking/IpAddress.cs
+++ b/src/csm/Networking/IpAddress.cs
@@ -74,6 +74,30 @@ namespace CSM.Networking
             }
         }
 
+        public static string GetVPNIpAddress()
+        {
+            try
+            {
+                //Create a new socket
+                using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, 0))
+                {
+                    // Try to connect to random address in 25.0.0.0/8 subnet used by Hamachi
+                    socket.Connect("25.0.0.0", 65530);
+                    // If local address used starts with 25., Hamachi is installed and active
+                    if (socket.LocalEndPoint is IPEndPoint endPoint && endPoint.Address.GetAddressBytes()[0] == 25)
+                    {
+                        return endPoint.Address.ToString();
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+
+            return null;
+        }
+
         public static PortState CheckPort(int port)
         {
             CSMWebClient client = new CSMWebClient();

--- a/src/csm/Networking/Server.cs
+++ b/src/csm/Networking/Server.cs
@@ -121,21 +121,29 @@ namespace CSM.Networking
 
         private void CheckPort()
         {
+            string vpnIp = IpAddress.GetVPNIpAddress();
             PortState state = IpAddress.CheckPort(Config.Port);
             string message;
             bool portOpen = false;
             switch (state.status)
             {
                 case HttpStatusCode.ServiceUnavailable: // Could not reach port
-                    if (automaticSuccess)
+                    if (vpnIp != null)
                     {
                         message =
-                            "It was tried to forward the port automatically, but the server is not reachable from the internet. Manual port forwarding is required.";
+                            "Server is not reachable from the internet. Players can connect over Hamachi using the IP address " +
+                            vpnIp;
+                        portOpen = true; // This is an OK state
+                    }
+                    else if (automaticSuccess)
+                    {
+                        message =
+                                "It was tried to forward the port automatically, but the server is not reachable from the internet. Manual port forwarding is required. See the \"Manage Server\" menu for more info.";
                     }
                     else
                     {
                         message =
-                            "Port could not be forwarded automatically and server is not reachable from the internet. Manual port forwarding is required.";
+                            "Port could not be forwarded automatically and server is not reachable from the internet. Manual port forwarding is required. See the \"Manage Server\" menu for more info.";
                     }
                     break;
                 case HttpStatusCode.OK: // Success
@@ -149,9 +157,20 @@ namespace CSM.Networking
                     {
                         message = "Server is reachable from the internet!";
                     }
+
+                    if (vpnIp != null)
+                    {
+                        message += " Players can also connect over Hamachi, although you don't need it.";
+                    }
                     break;
                 default: // Something failed
-                    if (automaticSuccess)
+                    if (vpnIp != null)
+                    {
+                        message =
+                            "Error while checking server port from the internet. Players should still be able to connect over the Hamachi IP address " +
+                            vpnIp;
+                    }
+                    else if (automaticSuccess)
                     {
                         message = "Port was forwarded automatically, but couldn't be checked due to error: " +
                                   state.message;

--- a/src/csm/Panels/HostGamePanel.cs
+++ b/src/csm/Panels/HostGamePanel.cs
@@ -22,6 +22,7 @@ namespace CSM.Panels
         private UILabel _connectionStatus;
         private UILabel _localIp;
         private UILabel _externalIp;
+        private UILabel _vpnIp;
 
         private UIButton _createButton;
         private UIButton _closeButton;
@@ -43,7 +44,7 @@ namespace CSM.Panels
             color = new Color32(110, 110, 110, 250);
 
             width = 360;
-            height = 580;
+            height = 600;
             relativePosition = PanelManager.GetCenterPosition(this);
 
             // Title Label
@@ -81,9 +82,6 @@ namespace CSM.Panels
             _connectionStatus.textAlignment = UIHorizontalAlignment.Center;
             _connectionStatus.textColor = new Color32(255, 0, 0, 255);
 
-            // Request IP addresses async
-            new Thread(RequestIPs).Start();
-
             // Create Local IP Label
             _localIp = this.CreateLabel("", new Vector2(10, -380));
             _localIp.textAlignment = UIHorizontalAlignment.Center;
@@ -92,12 +90,26 @@ namespace CSM.Panels
             _externalIp = this.CreateLabel("", new Vector2(10, -400));
             _externalIp.textAlignment = UIHorizontalAlignment.Center;
 
+            // Create VPN IP Label
+            _vpnIp = this.CreateLabel("", new Vector2(10, -420));
+            _vpnIp.textAlignment = UIHorizontalAlignment.Center;
+
+            // Request IP addresses async
+            new Thread(RequestIPs).Start();
+            this.eventVisibilityChanged += (component, visible) =>
+            {
+                if (visible)
+                {
+                    new Thread(RequestIPs).Start();
+                }
+            };
+
             // Create Server Button
-            _createButton = this.CreateButton("Create Server", new Vector2(10, -445));
+            _createButton = this.CreateButton("Create Server", new Vector2(10, -465));
             _createButton.eventClick += OnCreateServerClick;
 
             // Close this dialog
-            _closeButton = this.CreateButton("Cancel", new Vector2(10, -515));
+            _closeButton = this.CreateButton("Cancel", new Vector2(10, -535));
             _closeButton.eventClick += (component, param) =>
             {
                 isVisible = false;
@@ -125,6 +137,7 @@ namespace CSM.Panels
             // Request ips
             string sLocalIp = IpAddress.GetLocalIpAddress();
             string sExternalIp = IpAddress.GetExternalIpAddress();
+            string sVpnIp = IpAddress.GetVPNIpAddress();
 
             // Change gui attributes in main thread
             Singleton<SimulationManager>.instance.m_ThreadingWrapper.QueueMainThread(() =>
@@ -134,6 +147,16 @@ namespace CSM.Panels
 
                 _externalIp.textColor = sExternalIp.Equals("Not found") ? new Color32(255, 0, 0, 255) : new Color32(0, 255, 0, 255);
                 _externalIp.text = $"External IP: {sExternalIp}";
+
+                if (sVpnIp != null)
+                {
+                    _vpnIp.textColor = new Color32(0, 255, 0, 255);
+                    _vpnIp.text = $"Hamachi IP: {sVpnIp}";
+                }
+                else
+                {
+                    _vpnIp.text = "";
+                }
             });
         }
 

--- a/src/csm/Panels/JoinGamePanel.cs
+++ b/src/csm/Panels/JoinGamePanel.cs
@@ -22,6 +22,7 @@ namespace CSM.Panels
 
         private UIButton _connectButton;
         private UIButton _closeButton;
+        private UIButton _troubleshootingButton;
 
         private UICheckBox _passwordBox;
         private UICheckBox _rememberBox;
@@ -106,6 +107,15 @@ namespace CSM.Panels
             _connectionStatus.textAlignment = UIHorizontalAlignment.Center;
             _connectionStatus.textColor = new Color32(255, 0, 0, 255);
 
+            _troubleshootingButton = this.CreateButton("?", new Vector2(170, -420), 25, 20);
+            _troubleshootingButton.isVisible = false;
+            _troubleshootingButton.eventClick += (component, param) =>
+            {
+                MessagePanel panel = PanelManager.ShowPanel<MessagePanel>();
+                int.TryParse(_portField.text, out int port);
+                panel.DisplayTroubleshooting(false, port);
+            };
+
             ModCompat.BuildModInfo(this);
 
             eventVisibilityChanged += (comp, visible) =>
@@ -126,6 +136,7 @@ namespace CSM.Panels
 
             _connectionStatus.textColor = new Color32(255, 255, 0, 255);
             _connectionStatus.text = "Connecting...";
+            _troubleshootingButton.isVisible = false;
 
             if (string.IsNullOrEmpty(_portField.text) || string.IsNullOrEmpty(_ipAddressField.text))
             {
@@ -164,6 +175,10 @@ namespace CSM.Panels
                     {
                         _connectionStatus.textColor = new Color32(255, 0, 0, 255);
                         _connectionStatus.text = MultiplayerManager.Instance.CurrentClient.ConnectionMessage;
+                        if (MultiplayerManager.Instance.CurrentClient.ShowTroubleshooting)
+                        {
+                            _troubleshootingButton.isVisible = true;
+                        }
                     }
                     else
                     {

--- a/src/csm/Panels/ManageGamePanel.cs
+++ b/src/csm/Panels/ManageGamePanel.cs
@@ -18,7 +18,7 @@ namespace CSM.Panels
         private UIButton _closeButton;
 
         private int _portVal;
-        private string _localIpVal, _externalIpVal;
+        private string _localIpVal, _externalIpVal, _vpnIpVal;
 
         public override void Start()
         {
@@ -28,8 +28,10 @@ namespace CSM.Panels
             backgroundSprite = "GenericPanel";
             color = new Color32(110, 110, 110, 250);
 
+            _vpnIpVal = IpAddress.GetVPNIpAddress();
+
             width = 360;
-            height = 445;
+            height = _vpnIpVal == null ? 420 : 495;
             relativePosition = PanelManager.GetCenterPosition(this);
 
             // Title Label
@@ -62,6 +64,8 @@ namespace CSM.Panels
             // External IP label
             this.CreateLabel("External IP:", new Vector2(10, -225));
 
+            _portState = this.CreateLabel("", new Vector2(140, -225));
+
             // External IP field
             _externalIpVal = IpAddress.GetExternalIpAddress();
             _externalIpField = this.CreateTextField(_externalIpVal, new Vector2(10, -250));
@@ -70,12 +74,23 @@ namespace CSM.Panels
             {
                 _externalIpField.text = _externalIpVal;
             };
-            
-            _portState = this.CreateLabel("", new Vector2(10, -310));
-            _portState.textAlignment = UIHorizontalAlignment.Center;
+
+            if (_vpnIpVal != null)
+            {
+                // VPN IP label
+                this.CreateLabel("Hamachi IP:", new Vector2(10, -300));
+
+                // VPN IP field
+                UITextField vpnIpField = this.CreateTextField(_vpnIpVal, new Vector2(10, -325));
+                vpnIpField.selectOnFocus = true;
+                vpnIpField.eventTextChanged += (ui, value) =>
+                {
+                    vpnIpField.text = _vpnIpVal;
+                };
+            }
 
             // Close this dialog
-            _closeButton = this.CreateButton("Close", new Vector2(10, -375));
+            _closeButton = this.CreateButton("Close", new Vector2(10, _vpnIpVal == null ? -340 : -415));
             _closeButton.eventClick += (component, param) =>
             {
                 isVisible = false;

--- a/src/csm/Panels/ManageGamePanel.cs
+++ b/src/csm/Panels/ManageGamePanel.cs
@@ -13,9 +13,12 @@ namespace CSM.Panels
         private UITextField _portField;
         private UITextField _localIpField;
         private UITextField _externalIpField;
+        private UITextField _vpnIpField;
+        private UILabel _vpnLabel;
         private UILabel _portState;
 
         private UIButton _closeButton;
+        private UIButton _troubleshootingButton;
 
         private int _portVal;
         private string _localIpVal, _externalIpVal, _vpnIpVal;
@@ -28,10 +31,8 @@ namespace CSM.Panels
             backgroundSprite = "GenericPanel";
             color = new Color32(110, 110, 110, 250);
 
-            _vpnIpVal = IpAddress.GetVPNIpAddress();
-
             width = 360;
-            height = _vpnIpVal == null ? 420 : 495;
+            height = 420;
             relativePosition = PanelManager.GetCenterPosition(this);
 
             // Title Label
@@ -64,30 +65,33 @@ namespace CSM.Panels
             // External IP label
             this.CreateLabel("External IP:", new Vector2(10, -225));
 
-            _portState = this.CreateLabel("", new Vector2(140, -225));
+            _portState = this.CreateLabel("", new Vector2(120, -225));
+            _troubleshootingButton = this.CreateButton("?", new Vector2(325, -225), 25, 20);
+            _troubleshootingButton.isVisible = false;
+            _troubleshootingButton.eventClick += (component, param) =>
+            {
+                MessagePanel panel = PanelManager.ShowPanel<MessagePanel>();
+                panel.DisplayTroubleshooting(true, _portVal, _vpnIpVal != null);
+            };
 
             // External IP field
-            _externalIpVal = IpAddress.GetExternalIpAddress();
-            _externalIpField = this.CreateTextField(_externalIpVal, new Vector2(10, -250));
+            _externalIpField = this.CreateTextField("", new Vector2(10, -250));
             _externalIpField.selectOnFocus = true;
             _externalIpField.eventTextChanged += (ui, value) =>
             {
                 _externalIpField.text = _externalIpVal;
             };
 
-            if (_vpnIpVal != null)
+            // VPN IP label
+            _vpnLabel = this.CreateLabel("Hamachi IP:", new Vector2(10, -300));
+            _vpnLabel.isVisible = false;
+            _vpnIpField = this.CreateTextField("", new Vector2(10, -325));
+            _vpnIpField.selectOnFocus = true;
+            _vpnIpField.isVisible = false;
+            _vpnIpField.eventTextChanged += (ui, value) =>
             {
-                // VPN IP label
-                this.CreateLabel("Hamachi IP:", new Vector2(10, -300));
-
-                // VPN IP field
-                UITextField vpnIpField = this.CreateTextField(_vpnIpVal, new Vector2(10, -325));
-                vpnIpField.selectOnFocus = true;
-                vpnIpField.eventTextChanged += (ui, value) =>
-                {
-                    vpnIpField.text = _vpnIpVal;
-                };
-            }
+                _vpnIpField.text = _vpnIpVal;
+            };
 
             // Close this dialog
             _closeButton = this.CreateButton("Close", new Vector2(10, _vpnIpVal == null ? -340 : -415));
@@ -96,26 +100,49 @@ namespace CSM.Panels
                 isVisible = false;
             };
 
-            new Thread(CheckPort).Start();
+            new Thread(UpdateWindow).Start();
 
             eventVisibilityChanged += (component, visible) =>
             {
                 if (!visible)
                     return;
 
-                _portVal = MultiplayerManager.Instance.CurrentServer.Config.Port;
-                _portField.text = _portVal.ToString();
-                new Thread(CheckPort).Start();
+                new Thread(UpdateWindow).Start();
             };
         }
 
-        private void CheckPort()
+        private void UpdateWindow()
         {
+            _vpnIpVal = IpAddress.GetVPNIpAddress();
+            _localIpVal = IpAddress.GetLocalIpAddress();
+            _externalIpVal = IpAddress.GetExternalIpAddress();
+
             Singleton<SimulationManager>.instance.m_ThreadingWrapper.QueueMainThread(() =>
             {
+                _localIpField.text = _localIpVal;
+                _externalIpField.text = _externalIpVal;
+
                 _portState.text = "Checking port...";
                 _portState.textColor = new Color32(255, 255, 0, 255);
                 _portState.tooltip = "Checking if port is reachable from the internet...";
+                _troubleshootingButton.isVisible = false;
+
+                _portVal = MultiplayerManager.Instance.CurrentServer.Config.Port;
+                _portField.text = _portVal.ToString();
+
+                height = _vpnIpVal == null ? 420 : 495;
+                _closeButton.position = new Vector2(10, _vpnIpVal == null ? -340 : -415);
+                if (_vpnIpVal == null)
+                {
+                    _vpnLabel.isVisible = false;
+                    _vpnIpField.isVisible = false;
+                }
+                else
+                {
+                    _vpnLabel.isVisible = true;
+                    _vpnIpField.isVisible = true;
+                    _vpnIpField.text = _vpnIpVal;
+                }
             });
 
             PortState state = IpAddress.CheckPort(_portVal);
@@ -127,6 +154,7 @@ namespace CSM.Panels
                         _portState.text = "Port is not reachable!";
                         _portState.textColor = new Color32(255, 0, 0, 255);
                         _portState.tooltip = state.message;
+                        _troubleshootingButton.isVisible = true;
                         break;
                     case HttpStatusCode.OK: // Success
                         _portState.text = "Port is reachable!";

--- a/src/csm/Panels/MessagePanel.cs
+++ b/src/csm/Panels/MessagePanel.cs
@@ -230,5 +230,73 @@ namespace CSM.Panels
 
             Show(true);
         }
+
+        public void DisplayTroubleshooting(bool isHost, int port=4230, bool hasVpn=false)
+        {
+            SetTitle("Troubleshooting");
+
+            string message;
+
+            if (isHost)
+            {
+                message = "When the port is not reachable, this can have\n" +
+                          "various reasons. You can try the following steps:\n\n" +
+                          "   - Forward the CSM port: You need to\n" +
+                          "     forward the port (" + port + " UDP)\n" +
+                          "     in your router. How this works depends on\n" +
+                          "     the router or internet provider.\n" +
+                          "   -> If it doesn't work yet, you might\n" +
+                          "     need to allow the port through the local\n" +
+                          "     Firewall (e.g. Windows Defender Firewall).\n" +
+                          "     You can find more info on the Internet.\n" +
+                          "   -> You can always check again if the\n" +
+                          "     port is working in the \"Manage Server\" menu.";
+                if (hasVpn)
+                {
+                    message += "\n\n   - Since Hamachi seems to be running,\n" +
+                               "     players can also connect using your\n" +
+                               "     Hamachi IP.";
+                }
+                else
+                {
+                    message += "\n\n   - Alternatively, you can use a VPN solution\n" +
+                               "     like Hamachi or ZeroTier.\n" +
+                               "     Follow the instructions of the respective\n" +
+                               "     tool. Then players can connect using the\n" +
+                               "     displayed IP address of the tool.\n" +
+                               "     You can then ignore any error messages\n" +
+                               "     regarding port forwarding.";
+                }
+            }
+            else
+            {
+                message = "When the \"Failed to connect\" message appears,\n" +
+                          "this can have various reasons. The hosting player\n" +
+                          "can try the following steps:\n\n" +
+                          "- Check if the port is reachable in the\n" +
+                          "  \"Manage Server\" menu\n" +
+                          "  - If yes, make sure you connect using the IP\n" +
+                          "    shown as \"External IP\" in that menu\n\n" +
+                          "- If not, you have two possibilities:\n" +
+                          "  1. Forward the CSM port: The hosting player\n" +
+                          "     needs to forward the port (" + port + " UDP)\n" +
+                          "     in their router. How this works depends on\n" +
+                          "     the router or internet provider.\n" +
+                          "   -> If it doesn't work yet, the host might\n" +
+                          "     need to allow the port through the local\n" +
+                          "     Firewall (e.g. Windows Defender Firewall).\n" +
+                          "     You can find more info on the Internet.\n" +
+                          "   -> The host can always check again if the\n" +
+                          "     port is working in the \"Manage Server\" menu.\n\n" +
+                          "  2. Use a VPN solution like Hamachi or ZeroTier.\n" +
+                          "     Follow the instructions of the respective\n" +
+                          "     tool. Then you can connect using the\n" +
+                          "     displayed IP address of the tool.";
+            }
+
+            SetMessage(message);
+
+            Show(true);
+        }
     }
 }


### PR DESCRIPTION
To improve the understanding of connection problems, some features have been added:
- Add "more info" button on client when it fails to connect
- Add "more info" button in "Manage Server" menu when the port is not reachable
- Troubleshooting panel shows info about port forwarding, Windows Firewall and using Hamachi or ZeroTier
- Detect Hamachi through the availability of the 25.0.0.0/8 subnet
- When Hamachi is detected, display IP address in Host Game and Manage Game panels
- Improve connection check messages, display different messages when Hamachi is detected

Sadly I didn't find a way to detect the use of ZeroTier. The `GetAllNetworkInterfaces` method doesn't work in Cities and ZeroTier can use multiple different IP subnets, so such a detection would not be reliable.

May close #295 if these changes are enough.