### PR TITLE
Implement NAT hole punching and make API server configurable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,13 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-    
+
+    - name: Set lower case owner name
+      run: |
+        echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+      env:
+        OWNER: '${{ github.repository_owner }}'
+
     - name: Build Docker Image
       working-directory: src/gs
       run: docker build -t ghcr.io/${{ env.OWNER_LC }}/apiserver:latest -t .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
 
     - name: Build Docker Image
       working-directory: src/gs
-      run: docker build -t ghcr.io/citiesskylinesmultiplayer/apiserver:latest -t .
+      run: docker build -t ghcr.io/citiesskylinesmultiplayer/apiserver:latest .
 
     - name: Save docker image
       run: docker save -o apiserver.tar ghcr.io/citiesskylinesmultiplayer/apiserver:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  build-csm:
     # Run this on windows
     runs-on: windows-latest
 
@@ -87,3 +87,31 @@ jobs:
       if: github.ref == 'refs/heads/master'
       working-directory: src/api
       run: nuget push CitiesSkylinesMultiplayer.API.${{ steps.csm_version.outputs.version }}.0.nupkg ${{secrets.NUGET_API_KEY}} -NonInteractive -Source https://api.nuget.org/v3/index.json
+
+  build-gs:
+    # Run this on windows
+    runs-on: windows-latest
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+    
+    - name: Build Docker Image
+      working-directory: src/gs
+      run: docker build -t ghcr.io/${{ env.OWNER_LC }}/apiserver:latest -t .
+
+    - name: Save docker image
+      run: docker save -o apiserver.tar ghcr.io/${{ env.OWNER_LC }}/apiserver:latest
+
+    - name: Login to docker registry
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      if: github.ref == 'refs/heads/master'
+      
+    - name: Push Docker Image
+      run: docker push ghcr.io/${{ env.OWNER_LC }}/apiserver:latest
+      if: github.ref == 'refs/heads/master'
+
+    - name: Upload Docker Image
+      uses: actions/upload-artifact@v3
+      with:
+        name: API Server Docker Image
+        path: apiserver.tar

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,25 +95,19 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    - name: Set lower case owner name
-      run: |
-        echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
-      env:
-        OWNER: '${{ github.repository_owner }}'
-
     - name: Build Docker Image
       working-directory: src/gs
-      run: docker build -t ghcr.io/${{ env.OWNER_LC }}/apiserver:latest -t .
+      run: docker build -t ghcr.io/citiesskylinesmultiplayer/apiserver:latest -t .
 
     - name: Save docker image
-      run: docker save -o apiserver.tar ghcr.io/${{ env.OWNER_LC }}/apiserver:latest
+      run: docker save -o apiserver.tar ghcr.io/citiesskylinesmultiplayer/apiserver:latest
 
     - name: Login to docker registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       if: github.ref == 'refs/heads/master'
       
     - name: Push Docker Image
-      run: docker push ghcr.io/${{ env.OWNER_LC }}/apiserver:latest
+      run: docker push ghcr.io/citiesskylinesmultiplayer/apiserver:latest
       if: github.ref == 'refs/heads/master'
 
     - name: Upload Docker Image

--- a/src/api/Networking/Status/ClientStatus.cs
+++ b/src/api/Networking/Status/ClientStatus.cs
@@ -12,6 +12,12 @@
         Disconnected,
 
         /// <summary>
+        ///     Before starting to actually connect, the global server
+        ///     is queried and NAT punchthrough is attempted.
+        /// </summary>
+        PreConnecting,
+
+        /// <summary>
         ///     The client is trying to connect to the server, this phase
         ///     can take up to 30 seconds.
         /// </summary>
@@ -33,6 +39,13 @@
         ///     The client is connected to the server and is
         ///     transmitting information.
         /// </summary>
-        Connected
+        Connected,
+
+        /// <summary>
+        ///     If the connection was rejected by the server.
+        ///     Special case to separate from "Disconnected" during
+        ///     connection attempts. If rejected, no other IPs need to be tried.
+        /// </summary>
+        Rejected
     }
 }

--- a/src/csm/CSM.cs
+++ b/src/csm/CSM.cs
@@ -3,6 +3,7 @@ using CitiesHarmony.API;
 using ColossalFramework.IO;
 using CSM.API;
 using CSM.Commands;
+using CSM.GS.Commands;
 using CSM.Injections;
 using CSM.Mods;
 using CSM.Panels;
@@ -25,6 +26,8 @@ namespace CSM
             ModCompat.Init();
 
             CommandInternal.Instance = new CommandInternal();
+            ApiCommand.Instance = new ApiCommand();
+            ApiCommand.Instance.RefreshModel();
         }
 
         public void OnEnabled()

--- a/src/csm/CSM.csproj
+++ b/src/csm/CSM.csproj
@@ -1,188 +1,190 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{63933537-DA87-4026-A44C-382298FBB399}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>CSM</RootNamespace>
-    <AssemblyName>CSM</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\assemblies\Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="ColossalManaged, Version=0.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\assemblies\ColossalManaged.dll</HintPath>
-    </Reference>
-    <Reference Include="ICities, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\assemblies\ICities.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\assemblies\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\assemblies\UnityEngine.UI.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Commands\CommandReceiver.cs" />
-    <Compile Include="Commands\CommandInternal.cs" />
-    <Compile Include="Commands\Data\Game\SpeedPauseReachedCommand.cs" />
-    <Compile Include="Commands\Data\Internal\ClientJoiningCommand.cs" />
-    <Compile Include="Commands\Data\Internal\ClientLevelLoadedCommand.cs" />
-    <Compile Include="Commands\Data\Internal\PlayerLocationCommand.cs" />
-    <Compile Include="Commands\Data\Game\SpeedPauseResponseCommand.cs" />
-    <Compile Include="Commands\Data\Game\SpeedPauseRequestCommand.cs" />
-    <Compile Include="Commands\Data\Internal\ChatMessageCommand.cs" />
-    <Compile Include="Commands\Data\Internal\ClientConnectCommand.cs" />
-    <Compile Include="Commands\Data\Internal\ClientDisconnectCommand.cs" />
-    <Compile Include="Commands\Data\Internal\ConnectionRequestCommand.cs" />
-    <Compile Include="Commands\Data\Internal\ConnectionResultCommand.cs" />
-    <Compile Include="Commands\Data\Internal\FinishTransactionCommand.cs" />
-    <Compile Include="Commands\Data\Internal\PlayerListCommand.cs" />
-    <Compile Include="Commands\Data\Internal\RequestWorldTransferCommand.cs" />
-    <Compile Include="Commands\Data\Internal\SlowdownCommand.cs" />
-    <Compile Include="Commands\Data\Internal\WorldTransferCommand.cs" />
-    <Compile Include="Commands\Handler\Game\SpeedPauseReachedHandler.cs" />
-    <Compile Include="Commands\Handler\Game\SpeedPauseResponseHandler.cs" />
-    <Compile Include="Commands\Handler\Game\SpeedPauseRequestHandler.cs" />
-    <Compile Include="Commands\Handler\Internal\ChatMessageHandler.cs" />
-    <Compile Include="Commands\Handler\Internal\ClientConnectHandler.cs" />
-    <Compile Include="Commands\Handler\Internal\ClientDisonnectHandler.cs" />
-    <Compile Include="Commands\Handler\Internal\ClientJoiningHandler.cs" />
-    <Compile Include="Commands\Handler\Internal\ClientLevelLoadedHandler.cs" />
-    <Compile Include="Commands\Handler\Internal\ConnectionRequestHandler.cs" />
-    <Compile Include="Commands\Handler\Internal\ConnectionResultHandler.cs" />
-    <Compile Include="Commands\Handler\Internal\FinishTransactionHandler.cs" />
-    <Compile Include="Commands\Handler\Internal\PlayerListHandler.cs" />
-    <Compile Include="Commands\Handler\Internal\PlayerLocationHandler.cs" />
-    <Compile Include="Commands\Handler\Internal\RequestWorldTransferHandler.cs" />
-    <Compile Include="Commands\Handler\Internal\SlowdownHandler.cs" />
-    <Compile Include="Commands\Handler\Internal\WorldTransferHandler.cs" />
-    <Compile Include="Container\ChatCommand.cs" />
-    <Compile Include="Container\ChirperMessage.cs" />
-    <Compile Include="Container\Tuple.cs" />
-    <Compile Include="Extensions\LoadingExtension.cs" />
-    <Compile Include="Extensions\ThreadingExtension.cs" />
-    <Compile Include="GS\Commands\ApiCommand.cs" />
-    <Compile Include="GS\Commands\CommandReceiver.cs" />
-    <Compile Include="GS\Commands\Data\ApiServer\ApiCommandBase.cs" />
-    <Compile Include="GS\Commands\Data\ApiServer\PortCheckRequestCommand.cs" />
-    <Compile Include="GS\Commands\Data\ApiServer\PortCheckResultCommand.cs" />
-    <Compile Include="GS\Commands\Data\ApiServer\ServerRegistrationCommand.cs" />
-    <Compile Include="GS\Commands\Handler\ApiServer\ApiCommandHandler.cs" />
-    <Compile Include="GS\Commands\Handler\ApiServer\PortCheckRequestHandler.cs" />
-    <Compile Include="GS\Commands\Handler\ApiServer\PortCheckResultHandler.cs" />
-    <Compile Include="GS\Commands\Handler\ApiServer\ServerRegistrationHandler.cs" />
-    <Compile Include="Helpers\AssemblyHelper.cs" />
-    <Compile Include="Helpers\SaveHelpers.cs" />
-    <Compile Include="Helpers\DLCHelper.cs" />
-    <Compile Include="Helpers\SlowdownHelper.cs" />
-    <Compile Include="Helpers\SpeedPauseHelper.cs" />
-    <Compile Include="Helpers\UiHelper.cs" />
-    <Compile Include="Injections\ChatHandler.cs" />
-    <Compile Include="Injections\ICameraHandler.cs" />
-    <Compile Include="Injections\MainMenuHandler.cs" />
-    <Compile Include="Injections\PauseMenuHandler.cs" />
-    <Compile Include="Injections\SpeedPauseHandler.cs" />
-    <Compile Include="Injections\TickLoopHandler.cs" />
-    <Compile Include="Models\ColorSurrogate.cs" />
-    <Compile Include="Models\QuaternionSurrogate.cs" />
-    <Compile Include="Models\ControlPointSurrogate.cs" />
-    <Compile Include="Models\Vector3Surrogate.cs" />
-    <Compile Include="Mods\ModCompat.cs" />
-    <Compile Include="Mods\ModSupport.cs" />
-    <Compile Include="Networking\Client.cs" />
-    <Compile Include="Networking\Config\ClientConfig.cs" />
-    <Compile Include="Networking\Config\ConfigData.cs" />
-    <Compile Include="Networking\Config\ServerConfig.cs" />
-    <Compile Include="Networking\IpAddress.cs" />
-    <Compile Include="Networking\MultiplayerManager.cs" />
-    <Compile Include="Networking\Server.cs" />
-    <Compile Include="Commands\TransactionHandler.cs" />
-    <Compile Include="Panels\ConnectedPlayersPanel.cs" />
-    <Compile Include="Panels\MessagePanel.cs" />
-    <Compile Include="Panels\PanelManager.cs" />
-    <Compile Include="Patcher.cs" />
-    <Compile Include="Settings.cs" />
-    <Compile Include="Panels\ChatLogPanel.cs" />
-    <Compile Include="Panels\ClientJoinPanel.cs" />
-    <Compile Include="Panels\SettingsPanel.cs" />
-    <Compile Include="Panels\ConnectionPanel.cs" />
-    <Compile Include="Panels\ManageGamePanel.cs" />
-    <Compile Include="Panels\HostGamePanel.cs" />
-    <Compile Include="Panels\JoinGamePanel.cs" />
-    <Compile Include="CSM.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Util\CSMWebClient.cs" />
-    <Compile Include="Util\Serializer.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="LiteNetLib">
-      <Version>0.9.4</Version>
-    </PackageReference>
-    <PackageReference Include="Open.Nat">
-      <Version>2.1.0</Version>
-    </PackageReference>
-    <PackageReference Include="protobuf-net">
-      <Version>2.4.7</Version>
-    </PackageReference>
-    <PackageReference Include="CitiesHarmony.API">
-      <Version>2.1.0</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\api\CSM.API.csproj">
-      <Project>{ab27eacd-b9a9-42bc-bf8a-3b25aabff6ca}</Project>
-      <Name>CSM.API</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\basegame\CSM.BaseGame.csproj">
-      <Project>{bfc8de00-f495-4388-9e36-f1471f8ed578}</Project>
-      <Name>CSM.BaseGame</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent Condition="$([MSBuild]::IsOsPlatform('windows'))">powershell -ExecutionPolicy Unrestricted -Command "$(SolutionDir)\scripts\build.ps1" -OutputDirectory $(TargetDir) -Install</PostBuildEvent>
-    <PostBuildEvent Condition="$([MSBuild]::IsOsPlatform('linux'))">pwsh "$(SolutionDir)scripts/build.ps1" -OutputDirectory "$(TargetDir)" -Install</PostBuildEvent>
-    <PostBuildEvent Condition="$([MSBuild]::IsOsPlatform('osx'))">pwsh "$(SolutionDir)scripts/build.ps1" -OutputDirectory "$(TargetDir)" -Install</PostBuildEvent>
-  </PropertyGroup>
+	<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<ProjectGuid>{63933537-DA87-4026-A44C-382298FBB399}</ProjectGuid>
+		<OutputType>Library</OutputType>
+		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<RootNamespace>CSM</RootNamespace>
+		<AssemblyName>CSM</AssemblyName>
+		<TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+		<FileAlignment>512</FileAlignment>
+		<TargetFrameworkProfile>
+		</TargetFrameworkProfile>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<DebugSymbols>true</DebugSymbols>
+		<DebugType>full</DebugType>
+		<Optimize>false</Optimize>
+		<OutputPath>bin\Debug\</OutputPath>
+		<DefineConstants>DEBUG;TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DebugType>pdbonly</DebugType>
+		<Optimize>true</Optimize>
+		<OutputPath>bin\Release\</OutputPath>
+		<DefineConstants>TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+	</PropertyGroup>
+	<ItemGroup>
+		<Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+			<SpecificVersion>False</SpecificVersion>
+			<HintPath>..\..\assemblies\Assembly-CSharp.dll</HintPath>
+		</Reference>
+		<Reference Include="ColossalManaged, Version=0.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+			<SpecificVersion>False</SpecificVersion>
+			<HintPath>..\..\assemblies\ColossalManaged.dll</HintPath>
+		</Reference>
+		<Reference Include="ICities, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+			<SpecificVersion>False</SpecificVersion>
+			<HintPath>..\..\assemblies\ICities.dll</HintPath>
+		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Configuration" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Runtime.Serialization" />
+		<Reference Include="System.ServiceModel" />
+		<Reference Include="System.Xml.Linq" />
+		<Reference Include="System.Data.DataSetExtensions" />
+		<Reference Include="System.Data" />
+		<Reference Include="System.Xml" />
+		<Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+			<SpecificVersion>False</SpecificVersion>
+			<HintPath>..\..\assemblies\UnityEngine.dll</HintPath>
+		</Reference>
+		<Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+			<SpecificVersion>False</SpecificVersion>
+			<HintPath>..\..\assemblies\UnityEngine.UI.dll</HintPath>
+		</Reference>
+	</ItemGroup>
+	<ItemGroup>
+		<Compile Include="Commands\CommandReceiver.cs" />
+		<Compile Include="Commands\CommandInternal.cs" />
+		<Compile Include="Commands\Data\Game\SpeedPauseReachedCommand.cs" />
+		<Compile Include="Commands\Data\Internal\ClientJoiningCommand.cs" />
+		<Compile Include="Commands\Data\Internal\ClientLevelLoadedCommand.cs" />
+		<Compile Include="Commands\Data\Internal\PlayerLocationCommand.cs" />
+		<Compile Include="Commands\Data\Game\SpeedPauseResponseCommand.cs" />
+		<Compile Include="Commands\Data\Game\SpeedPauseRequestCommand.cs" />
+		<Compile Include="Commands\Data\Internal\ChatMessageCommand.cs" />
+		<Compile Include="Commands\Data\Internal\ClientConnectCommand.cs" />
+		<Compile Include="Commands\Data\Internal\ClientDisconnectCommand.cs" />
+		<Compile Include="Commands\Data\Internal\ConnectionRequestCommand.cs" />
+		<Compile Include="Commands\Data\Internal\ConnectionResultCommand.cs" />
+		<Compile Include="Commands\Data\Internal\FinishTransactionCommand.cs" />
+		<Compile Include="Commands\Data\Internal\PlayerListCommand.cs" />
+		<Compile Include="Commands\Data\Internal\RequestWorldTransferCommand.cs" />
+		<Compile Include="Commands\Data\Internal\SlowdownCommand.cs" />
+		<Compile Include="Commands\Data\Internal\WorldTransferCommand.cs" />
+		<Compile Include="Commands\Handler\Game\SpeedPauseReachedHandler.cs" />
+		<Compile Include="Commands\Handler\Game\SpeedPauseResponseHandler.cs" />
+		<Compile Include="Commands\Handler\Game\SpeedPauseRequestHandler.cs" />
+		<Compile Include="Commands\Handler\Internal\ChatMessageHandler.cs" />
+		<Compile Include="Commands\Handler\Internal\ClientConnectHandler.cs" />
+		<Compile Include="Commands\Handler\Internal\ClientDisonnectHandler.cs" />
+		<Compile Include="Commands\Handler\Internal\ClientJoiningHandler.cs" />
+		<Compile Include="Commands\Handler\Internal\ClientLevelLoadedHandler.cs" />
+		<Compile Include="Commands\Handler\Internal\ConnectionRequestHandler.cs" />
+		<Compile Include="Commands\Handler\Internal\ConnectionResultHandler.cs" />
+		<Compile Include="Commands\Handler\Internal\FinishTransactionHandler.cs" />
+		<Compile Include="Commands\Handler\Internal\PlayerListHandler.cs" />
+		<Compile Include="Commands\Handler\Internal\PlayerLocationHandler.cs" />
+		<Compile Include="Commands\Handler\Internal\RequestWorldTransferHandler.cs" />
+		<Compile Include="Commands\Handler\Internal\SlowdownHandler.cs" />
+		<Compile Include="Commands\Handler\Internal\WorldTransferHandler.cs" />
+		<Compile Include="Container\ChatCommand.cs" />
+		<Compile Include="Container\ChirperMessage.cs" />
+		<Compile Include="Container\Tuple.cs" />
+		<Compile Include="Extensions\LoadingExtension.cs" />
+		<Compile Include="Extensions\ThreadingExtension.cs" />
+		<Compile Include="GS\Commands\ApiCommand.cs" />
+		<Compile Include="GS\Commands\CommandReceiver.cs" />
+		<Compile Include="..\gs\Commands\Data\ApiServer\ApiCommandBase.cs" Link="GS\Commands\Data\ApiServer\ApiCommandBase.cs" />
+		<Compile Include="..\gs\Commands\Data\ApiServer\PortCheckRequestCommand.cs" Link="GS\Commands\Data\ApiServer\PortCheckRequestCommand.cs" />
+		<Compile Include="..\gs\Commands\Data\ApiServer\PortCheckResultCommand.cs" Link="GS\Commands\Data\ApiServer\PortCheckResultCommand.cs" />
+		<Compile Include="..\gs\Commands\Data\ApiServer\ServerRegistrationCommand.cs" Link="GS\Commands\Data\ApiServer\ServerRegistrationCommand.cs" />
+		<Compile Include="GS\Commands\Handler\ApiServer\ApiCommandHandler.cs" />
+		<Compile Include="GS\Commands\Handler\ApiServer\PortCheckRequestHandler.cs" />
+		<Compile Include="GS\Commands\Handler\ApiServer\PortCheckResultHandler.cs" />
+		<Compile Include="GS\Commands\Handler\ApiServer\ServerRegistrationHandler.cs" />
+		<Compile Include="Helpers\AssemblyHelper.cs" />
+		<Compile Include="Helpers\SaveHelpers.cs" />
+		<Compile Include="Helpers\DLCHelper.cs" />
+		<Compile Include="Helpers\SlowdownHelper.cs" />
+		<Compile Include="Helpers\SpeedPauseHelper.cs" />
+		<Compile Include="Helpers\UiHelper.cs" />
+		<Compile Include="Injections\ChatHandler.cs" />
+		<Compile Include="Injections\ICameraHandler.cs" />
+		<Compile Include="Injections\MainMenuHandler.cs" />
+		<Compile Include="Injections\PauseMenuHandler.cs" />
+		<Compile Include="Injections\SpeedPauseHandler.cs" />
+		<Compile Include="Injections\TickLoopHandler.cs" />
+		<Compile Include="Models\ColorSurrogate.cs" />
+		<Compile Include="Models\QuaternionSurrogate.cs" />
+		<Compile Include="Models\ControlPointSurrogate.cs" />
+		<Compile Include="Models\Vector3Surrogate.cs" />
+		<Compile Include="Mods\ModCompat.cs" />
+		<Compile Include="Mods\ModSupport.cs" />
+		<Compile Include="Networking\Client.cs" />
+		<Compile Include="Networking\Config\ClientConfig.cs" />
+		<Compile Include="Networking\Config\ConfigData.cs" />
+		<Compile Include="Networking\Config\ServerConfig.cs" />
+		<Compile Include="Networking\IpAddress.cs" />
+		<Compile Include="Networking\MultiplayerManager.cs" />
+		<Compile Include="Networking\Server.cs" />
+		<Compile Include="Commands\TransactionHandler.cs" />
+		<Compile Include="Panels\ConnectedPlayersPanel.cs" />
+		<Compile Include="Panels\MessagePanel.cs" />
+		<Compile Include="Panels\PanelManager.cs" />
+		<Compile Include="Patcher.cs" />
+		<Compile Include="Settings.cs" />
+		<Compile Include="Panels\ChatLogPanel.cs" />
+		<Compile Include="Panels\ClientJoinPanel.cs" />
+		<Compile Include="Panels\SettingsPanel.cs" />
+		<Compile Include="Panels\ConnectionPanel.cs" />
+		<Compile Include="Panels\ManageGamePanel.cs" />
+		<Compile Include="Panels\HostGamePanel.cs" />
+		<Compile Include="Panels\JoinGamePanel.cs" />
+		<Compile Include="CSM.cs" />
+		<Compile Include="Properties\AssemblyInfo.cs" />
+		<Compile Include="Util\CSMWebClient.cs">
+			<SubType>Component</SubType>
+		</Compile>
+		<Compile Include="Util\Serializer.cs" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="LiteNetLib">
+			<Version>0.9.4</Version>
+		</PackageReference>
+		<PackageReference Include="Open.Nat">
+			<Version>2.1.0</Version>
+		</PackageReference>
+		<PackageReference Include="protobuf-net">
+			<Version>2.4.7</Version>
+		</PackageReference>
+		<PackageReference Include="CitiesHarmony.API">
+			<Version>2.1.0</Version>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\api\CSM.API.csproj">
+			<Project>{ab27eacd-b9a9-42bc-bf8a-3b25aabff6ca}</Project>
+			<Name>CSM.API</Name>
+		</ProjectReference>
+		<ProjectReference Include="..\basegame\CSM.BaseGame.csproj">
+			<Project>{bfc8de00-f495-4388-9e36-f1471f8ed578}</Project>
+			<Name>CSM.BaseGame</Name>
+		</ProjectReference>
+	</ItemGroup>
+	<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+	<PropertyGroup>
+		<PostBuildEvent Condition="$([MSBuild]::IsOsPlatform('windows'))">powershell -ExecutionPolicy Unrestricted -Command "$(SolutionDir)\scripts\build.ps1" -OutputDirectory $(TargetDir) -Install</PostBuildEvent>
+		<PostBuildEvent Condition="$([MSBuild]::IsOsPlatform('linux'))">pwsh "$(SolutionDir)scripts/build.ps1" -OutputDirectory "$(TargetDir)" -Install</PostBuildEvent>
+		<PostBuildEvent Condition="$([MSBuild]::IsOsPlatform('osx'))">pwsh "$(SolutionDir)scripts/build.ps1" -OutputDirectory "$(TargetDir)" -Install</PostBuildEvent>
+	</PropertyGroup>
 </Project>

--- a/src/csm/CSM.csproj
+++ b/src/csm/CSM.csproj
@@ -102,6 +102,16 @@
     <Compile Include="Container\Tuple.cs" />
     <Compile Include="Extensions\LoadingExtension.cs" />
     <Compile Include="Extensions\ThreadingExtension.cs" />
+    <Compile Include="GS\Commands\ApiCommand.cs" />
+    <Compile Include="GS\Commands\CommandReceiver.cs" />
+    <Compile Include="GS\Commands\Data\ApiServer\ApiCommandBase.cs" />
+    <Compile Include="GS\Commands\Data\ApiServer\PortCheckRequestCommand.cs" />
+    <Compile Include="GS\Commands\Data\ApiServer\PortCheckResultCommand.cs" />
+    <Compile Include="GS\Commands\Data\ApiServer\ServerRegistrationCommand.cs" />
+    <Compile Include="GS\Commands\Handler\ApiServer\ApiCommandHandler.cs" />
+    <Compile Include="GS\Commands\Handler\ApiServer\PortCheckRequestHandler.cs" />
+    <Compile Include="GS\Commands\Handler\ApiServer\PortCheckResultHandler.cs" />
+    <Compile Include="GS\Commands\Handler\ApiServer\ServerRegistrationHandler.cs" />
     <Compile Include="Helpers\AssemblyHelper.cs" />
     <Compile Include="Helpers\SaveHelpers.cs" />
     <Compile Include="Helpers\DLCHelper.cs" />

--- a/src/csm/Commands/CommandInternal.cs
+++ b/src/csm/Commands/CommandInternal.cs
@@ -92,7 +92,8 @@ namespace CSM.Commands
         /// <param name="command">The command to send.</param>
         public void SendToServer(CommandBase command)
         {
-            if (MultiplayerManager.Instance.CurrentClient.Status == ClientStatus.Disconnected)
+            if (MultiplayerManager.Instance.CurrentClient.Status == ClientStatus.Disconnected ||
+                MultiplayerManager.Instance.CurrentClient.Status == ClientStatus.PreConnecting)
                 return;
 
             TransactionHandler.StartTransaction(command);

--- a/src/csm/Commands/Handler/Internal/ConnectionResultHandler.cs
+++ b/src/csm/Commands/Handler/Internal/ConnectionResultHandler.cs
@@ -39,7 +39,7 @@ namespace CSM.Commands.Handler.Internal
             {
                 Log.Info($"Could not connect: {command.Reason}");
                 MultiplayerManager.Instance.CurrentClient.ConnectionMessage = command.Reason;
-                MultiplayerManager.Instance.CurrentClient.Disconnect();
+                MultiplayerManager.Instance.CurrentClient.ConnectRejected();
                 if (command.Reason.Contains("DLC")) // No other way to detect if we should display the box
                 {
                     DLCHelper.DLCComparison compare = DLCHelper.Compare(command.ExpansionBitMask, DLCHelper.GetOwnedExpansions(), command.ModderPackBitMask, DLCHelper.GetOwnedModderPacks());

--- a/src/csm/GS/Commands/ApiCommand.cs
+++ b/src/csm/GS/Commands/ApiCommand.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using CSM.API;
+using CSM.API.Commands;
+using CSM.GS.Commands.Data.ApiServer;
+using CSM.GS.Commands.Handler.ApiServer;
+using CSM.Helpers;
+using CSM.Networking;
+using ProtoBuf.Meta;
+
+namespace CSM.GS.Commands
+{
+    public class ApiCommand
+    {
+        public static ApiCommand Instance;
+
+        private readonly Dictionary<Type, ApiCommandHandler> _apiCmdMapping = new Dictionary<Type, ApiCommandHandler>();
+
+        public TypeModel ApiModel { get; private set; }
+
+        /// <summary>
+        ///     This method is used to send a command to the API server.
+        ///     Does only work if the current game acts as a server.
+        /// </summary>
+        /// <param name="command">The command to send.</param>
+        public void SendToApiServer(ApiCommandBase command)
+        {
+            if (MultiplayerManager.Instance.CurrentRole == MultiplayerRole.Server)
+                MultiplayerManager.Instance.CurrentServer.SendToApiServer(command);
+        }
+
+        /// <summary>
+        ///     This method is used to get the handler of given API command.
+        /// </summary>
+        /// <param name="commandType">The Type of a ApiCommandBase subclass.</param>
+        /// <returns>The handler for the given command.</returns>
+        public ApiCommandHandler GetApiCommandHandler(Type commandType)
+        {
+            _apiCmdMapping.TryGetValue(commandType, out ApiCommandHandler handler);
+            return handler;
+        }
+
+        /// <summary>
+        ///     Serializes the command into a byte array for sending over the network.
+        /// </summary>
+        /// <returns>A byte array containing the message.</returns>
+        public static byte[] Serialize(ApiCommandBase cmd)
+        {
+            byte[] result;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                Instance.ApiModel.Serialize(stream, cmd);
+                result = stream.ToArray();
+            }
+
+            return result;
+        }
+
+        public void RefreshModel()
+        {
+            _apiCmdMapping.Clear();
+            try
+            {
+                // First, setup protocol model for the API server:
+                Type[] apiHandlers = AssemblyHelper.FindClassesInCSM(typeof(ApiCommandHandler)).ToArray();
+                Log.Info($"Initializing API data model with {apiHandlers.Length} commands...");
+                // Create a protobuf model
+                RuntimeTypeModel apiModel = RuntimeTypeModel.Create();
+                // Add base command to the protobuf model with all attributes
+                apiModel.Add(typeof(ApiCommandBase), true);
+                MetaType baseApiCmd = apiModel[typeof(ApiCommandBase)];
+
+                // Lowest id of the subclasses
+                int id = 100;
+
+                // Create instances of the handlers, initialize mappings and register command subclasses in the protobuf model
+                foreach (Type type in apiHandlers)
+                {
+                    ApiCommandHandler handler = (ApiCommandHandler)Activator.CreateInstance(type);
+                    _apiCmdMapping.Add(handler.GetDataType(), handler);
+
+                    // Add subtype to the protobuf model with all attributes
+                    baseApiCmd.AddSubType(id, handler.GetDataType());
+                    apiModel.Add(handler.GetDataType(), true);
+
+                    id++;
+                }
+
+                // Compile the protobuf model
+                apiModel.CompileInPlace();
+
+                ApiModel = apiModel;
+            }
+            catch (Exception ex)
+            {
+                Log.Error("Failed to initialize data model", ex);
+            }
+        }
+    }
+}

--- a/src/csm/GS/Commands/CommandReceiver.cs
+++ b/src/csm/GS/Commands/CommandReceiver.cs
@@ -1,0 +1,49 @@
+﻿using System.IO;
+using CSM.API;
+using CSM.GS.Commands.Data.ApiServer;
+using CSM.GS.Commands.Handler.ApiServer;
+using LiteNetLib;
+
+namespace CSM.GS.Commands
+{
+    public static class CommandReceiver
+    {
+        /// <summary>
+        ///     This method is used to parse an incoming message from the API server
+        ///     and execute the appropriate action.
+        /// </summary>
+        /// <param name="reader">The incoming packet including the command type byte.</param>
+        public static void Parse(NetPacketReader reader)
+        {
+            ApiCommandBase cmd = Deserialize(reader.GetRemainingBytes());
+
+            Log.Debug($"Received {cmd.GetType().Name}");
+
+            ApiCommandHandler handler = ApiCommand.Instance.GetApiCommandHandler(cmd.GetType());
+            if (handler == null)
+            {
+                Log.Error($"API command {cmd.GetType().Name} not found!");
+                return;
+            }
+
+            handler.Parse(cmd);
+        }
+
+        /// <summary>
+        ///     Deserialize the command from a byte array.
+        /// </summary>
+        /// <param name="message">A byte array of the message</param>
+        /// <returns>The deserialized command.</returns>
+        private static ApiCommandBase Deserialize(byte[] message)
+        {
+            ApiCommandBase result;
+
+            using (MemoryStream stream = new MemoryStream(message))
+            {
+                result = (ApiCommandBase)ApiCommand.Instance.ApiModel.Deserialize(stream, null, typeof(ApiCommandBase));
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/csm/GS/Commands/Data
+++ b/src/csm/GS/Commands/Data
@@ -1,1 +1,0 @@
-../../../gs/Commands/Data

--- a/src/csm/GS/Commands/Data
+++ b/src/csm/GS/Commands/Data
@@ -1,0 +1,1 @@
+../../../gs/Commands/Data

--- a/src/csm/GS/Commands/Handler/ApiServer/ApiCommandHandler.cs
+++ b/src/csm/GS/Commands/Handler/ApiServer/ApiCommandHandler.cs
@@ -1,0 +1,27 @@
+using System;
+using CSM.GS.Commands.Data.ApiServer;
+
+namespace CSM.GS.Commands.Handler.ApiServer
+{
+    public abstract class ApiCommandHandler
+    {
+        public abstract Type GetDataType();
+
+        public abstract void Parse(ApiCommandBase message);
+    }
+
+    public abstract class ApiCommandHandler<C> : ApiCommandHandler where C : ApiCommandBase
+    {
+        protected abstract void Handle(C command);
+
+        public override Type GetDataType()
+        {
+            return typeof(C);
+        }
+
+        public override void Parse(ApiCommandBase command)
+        {
+            Handle((C) command);
+        }
+    }
+}

--- a/src/csm/GS/Commands/Handler/ApiServer/PortCheckRequestHandler.cs
+++ b/src/csm/GS/Commands/Handler/ApiServer/PortCheckRequestHandler.cs
@@ -1,0 +1,12 @@
+﻿using CSM.GS.Commands.Data.ApiServer;
+
+namespace CSM.GS.Commands.Handler.ApiServer
+{
+    public class PortCheckRequestHandler : ApiCommandHandler<PortCheckRequestCommand>
+    {
+        protected override void Handle(PortCheckRequestCommand command)
+        {
+            // Do nothing, this is a packet for the global server
+        }
+    }
+}

--- a/src/csm/GS/Commands/Handler/ApiServer/PortCheckResultHandler.cs
+++ b/src/csm/GS/Commands/Handler/ApiServer/PortCheckResultHandler.cs
@@ -1,0 +1,86 @@
+﻿using CSM.API;
+using CSM.GS.Commands.Data.ApiServer;
+using CSM.Networking;
+using CSM.Panels;
+
+namespace CSM.GS.Commands.Handler.ApiServer
+{
+    public class PortCheckResultHandler : ApiCommandHandler<PortCheckResultCommand>
+    {
+        protected override void Handle(PortCheckResultCommand command)
+        {
+            string vpnIp = IpAddress.GetVPNIpAddress();
+            bool automaticSuccess = MultiplayerManager.Instance.CurrentServer.AutomaticSuccess;
+            string message;
+            bool portOpen = false;
+            switch (command.State)
+            {
+                case PortCheckResult.Unreachable:
+                    if (vpnIp != null)
+                    {
+                        message =
+                            "Server is not reachable from the internet. Players can connect over Hamachi using the IP address " +
+                            vpnIp;
+                        portOpen = true; // This is an OK state
+                    }
+                    else if (automaticSuccess)
+                    {
+                        message =
+                                "It was tried to forward the port automatically, but the server is not reachable from the internet. Manual port forwarding is required. See the \"Manage Server\" menu for more info.";
+                    }
+                    else
+                    {
+                        message =
+                            "Port could not be forwarded automatically and server is not reachable from the internet. Manual port forwarding is required. See the \"Manage Server\" menu for more info.";
+                    }
+                    break;
+                case PortCheckResult.Reachable:
+                    portOpen = true;
+                    if (automaticSuccess)
+                    {
+                        message =
+                            "Port was forwarded automatically and server is reachable from the internet!";
+                    }
+                    else
+                    {
+                        message = "Server is reachable from the internet!";
+                    }
+
+                    if (vpnIp != null)
+                    {
+                        message += " Players can also connect over Hamachi, although you don't need it.";
+                    }
+                    break;
+                case PortCheckResult.Error:
+                    if (vpnIp != null)
+                    {
+                        message =
+                            "Error while checking server port from the internet. Players should still be able to connect over the Hamachi IP address " +
+                            vpnIp;
+                    }
+                    else if (automaticSuccess)
+                    {
+                        message = "Port was forwarded automatically, but couldn't be checked due to error: " +
+                                  command.Message;
+                    }
+                    else
+                    {
+                        message = "Port could not be forwarded automatically, and couldn't be checked due to error: " +
+                                  command.Message;
+                    }
+                    break;
+                default:
+                    message = "Unknown response while checking server port from the internet.";
+                    break;
+            }
+
+            if (!portOpen)
+            {
+                Log.Warn(message);
+            }
+            Chat.Instance.PrintGameMessage(portOpen ? Chat.MessageType.Normal : Chat.MessageType.Warning, message);
+
+            PanelManager.GetPanel<ManageGamePanel>()?.SetPortState(command);
+        }
+    }
+}

--- a/src/csm/GS/Commands/Handler/ApiServer/ServerRegistrationHandler.cs
+++ b/src/csm/GS/Commands/Handler/ApiServer/ServerRegistrationHandler.cs
@@ -1,0 +1,12 @@
+using CSM.GS.Commands.Data.ApiServer;
+
+namespace CSM.GS.Commands.Handler.ApiServer
+{
+    public class ServerRegistrationHandler : ApiCommandHandler<ServerRegistrationCommand>
+    {
+        protected override void Handle(ServerRegistrationCommand command)
+        {
+            // Do nothing, this is a packet for the global server
+        }
+    }
+}

--- a/src/csm/Injections/MainMenuHandler.cs
+++ b/src/csm/Injections/MainMenuHandler.cs
@@ -37,7 +37,7 @@ namespace CSM.Injections
         {
             try
             {
-                string latest = new CSMWebClient().DownloadString("http://api.citiesskylinesmultiplayer.com/api/version");
+                string latest = new CSMWebClient().DownloadString($"http://{CSM.Settings.ApiServer}/api/version");
                 latest = latest.Substring(1);
                 string[] versionParts = latest.Split('.');
                 Version latestVersion = new Version(int.Parse(versionParts[0]), int.Parse(versionParts[1]));

--- a/src/csm/Networking/Client.cs
+++ b/src/csm/Networking/Client.cs
@@ -55,6 +55,12 @@ namespace CSM.Networking
         /// </summary>
         public string ConnectionMessage { get; set; } = "Unknown error";
 
+        /// <summary>
+        ///     If the join game panel should show connection troubleshooting
+        ///     information.
+        /// </summary>
+        public bool ShowTroubleshooting { get; set; } = false;
+
         private bool MainMenuEventProcessing = false;
 
         public Client()
@@ -78,6 +84,7 @@ namespace CSM.Networking
         /// <returns>True if the client is connected to the server, false if not</returns>
         public bool Connect(ClientConfig clientConfig)
         {
+            ShowTroubleshooting = false;
             // Let the user know that we are trying to connect to a server
             Log.Info($"Attempting to connect to server at {clientConfig.HostAddress}:{clientConfig.Port}...");
 
@@ -123,6 +130,7 @@ namespace CSM.Networking
             catch (Exception ex)
             {
                 ConnectionMessage = "Failed to connect.";
+                ShowTroubleshooting = true;
                 Log.Error($"Failed to connect to {Config.HostAddress}:{Config.Port}", ex);
                 Chat.Instance.PrintGameMessage(Chat.MessageType.Error, $"Failed to connect: {ex.Message}");
                 Disconnect();
@@ -268,7 +276,10 @@ namespace CSM.Networking
         private void ListenerOnPeerDisconnectedEvent(NetPeer peer, DisconnectInfo disconnectInfo)
         {
             if (Status == ClientStatus.Connecting)
+            {
                 ConnectionMessage = "Failed to connect!";
+                ShowTroubleshooting = true;
+            }
 
             // Log the error message
             Log.Info($"Disconnected from server. Message: {disconnectInfo.Reason}, Code: {disconnectInfo.SocketErrorCode}");

--- a/src/csm/Networking/Client.cs
+++ b/src/csm/Networking/Client.cs
@@ -55,13 +55,17 @@ namespace CSM.Networking
         /// </summary>
         public string ConnectionMessage { get; set; } = "Unknown error";
 
-        private bool MainMenuEventProcessing = false;
+        private bool _mainMenuEventProcessing = false;
 
         public Client()
         {
             // Set up network items
             EventBasedNetListener listener = new EventBasedNetListener();
-            _netClient = new LiteNetLib.NetManager(listener);
+            _netClient = new LiteNetLib.NetManager(listener)
+            {
+                NatPunchEnabled = true,
+                UnconnectedMessagesEnabled = true
+            };
 
             // Listen to events
             listener.NetworkReceiveEvent += ListenerOnNetworkReceiveEvent;
@@ -81,21 +85,13 @@ namespace CSM.Networking
             // Let the user know that we are trying to connect to a server
             Log.Info($"Attempting to connect to server at {clientConfig.HostAddress}:{clientConfig.Port}...");
 
-            // if we are currently trying to connect, cancel
-            // and try again.
-            if (Status == ClientStatus.Connecting)
+            if (Status != ClientStatus.Disconnected)
             {
-                Log.Info("Current status is 'connecting', attempting to disconnect first.");
-                Disconnect();
+                Log.Warn("Current status is not disconnected, ignoring connection attempt.");
+                return false;
             }
 
-            // The client is already connected so we need to
-            // disconnect.
-            if (Status == ClientStatus.Connected)
-            {
-                Log.Info("Current status is 'connected', attempting to disconnect first.");
-                Disconnect();
-            }
+            Status = ClientStatus.PreConnecting;
 
             // Set the configuration
             Config = clientConfig;
@@ -107,25 +103,95 @@ namespace CSM.Networking
             if (!result)
             {
                 Log.Error("The client failed to start.");
-                ConnectionMessage = "The client failed to start.";
+                ConnectionMessage = "Client failed to start.";
                 Disconnect(); // make sure we are fully disconnected
                 return false;
             }
 
-            Log.Info("Set status to 'connecting'...");
+            return SetupHolePunching();
+        }
 
+        private bool SetupHolePunching()
+        {
+            // Given string to IP address (resolves domain names).
+            IPAddress resolvedAddress;
+            try
+            {
+                resolvedAddress = NetUtils.ResolveAddress(Config.HostAddress);
+            }
+            catch
+            {
+                ConnectionMessage = "Invalid server IP";
+                Disconnect(); // make sure we are fully disconnected
+                return false;
+            }
+
+            EventBasedNatPunchListener natPunchListener = new EventBasedNatPunchListener();
+            Stopwatch timeoutWatch = new Stopwatch();
+
+            // Callback on for each possible IP address to connect to the server.
+            // Can potentially be called multiple times (local and public IP address).
+            natPunchListener.NatIntroductionSuccess += (point, type, token) =>
+            {
+                timeoutWatch.Stop();
+
+                if (Status == ClientStatus.PreConnecting)
+                {
+                    Log.Info($"Trying endpoint {point} after NAT hole punch...");
+                    bool success = DoConnect(point);
+                    if (!success)
+                    {
+                        Status = Status == ClientStatus.Rejected ? ClientStatus.Disconnected : ClientStatus.PreConnecting;
+                    }
+                }
+
+                timeoutWatch.Start();
+            };
+
+            // Register listener and send request to global server
+            _netClient.NatPunchModule.Init(natPunchListener);
+            _netClient.NatPunchModule.SendNatIntroduceRequest(new IPEndPoint(IpAddress.GetIpv4(CSM.Settings.ApiServer), 4240), $"client_{resolvedAddress}");
+
+            timeoutWatch.Start();
+            // Wait for NatPunchModule responses.
+            // 5 seconds include only the time waiting for nat punch management.
+            // Connection attempts have their own timeout in the DoConnect method
+            // The waitWatch is paused during an connection attempt.
+            while (Status == ClientStatus.PreConnecting && timeoutWatch.Elapsed < TimeSpan.FromSeconds(5))
+            {
+                _netClient.NatPunchModule.PollEvents();
+                // Wait 50ms
+                Thread.Sleep(50);
+            }
+
+            if (Status == ClientStatus.PreConnecting) // If timeout, try exact given address
+            {
+                Log.Info($"No registered server on GS found, trying exact given address {resolvedAddress}:{Config.Port}...");
+                bool success = DoConnect(new IPEndPoint(resolvedAddress, Config.Port));
+                if (!success)
+                {
+                    Disconnect(); // Make sure we are fully disconnected
+                    return false;
+                }
+
+                return true;
+            }
+
+            return Status != ClientStatus.Disconnected;
+        }
+
+        private bool DoConnect(IPEndPoint point)
+        {
             // Try connect to server, update the status to say that
             // we are trying to connect.
             try
             {
-                _netClient.Connect(Config.HostAddress, Config.Port, "CSM");
+                _netClient.Connect(point, "CSM");
             }
             catch (Exception ex)
             {
                 ConnectionMessage = "Failed to connect.";
-                Log.Error($"Failed to connect to {Config.HostAddress}:{Config.Port}", ex);
-                Chat.Instance.PrintGameMessage(Chat.MessageType.Error, $"Failed to connect: {ex.Message}");
-                Disconnect();
+                Log.Error($"Failed to connect to {point.Address}:{point.Port} ", ex);
                 return false;
             }
 
@@ -140,7 +206,7 @@ namespace CSM.Networking
             waitWatch.Start();
 
             // Try connect for 30 seconds
-            while (waitWatch.Elapsed < TimeSpan.FromSeconds(30))
+            while (waitWatch.Elapsed < TimeSpan.FromSeconds(10))
             {
                 // If we connect, exit the loop and return true
                 if (Status == ClientStatus.Connected || Status == ClientStatus.Downloading || Status == ClientStatus.Loading)
@@ -154,7 +220,11 @@ namespace CSM.Networking
                 if (Status == ClientStatus.Disconnected)
                 {
                     Log.Warn("Client disconnected while in connecting loop.");
-                    Disconnect(); // make sure we are fully disconnected
+                    return false;
+                }
+
+                if (Status == ClientStatus.Rejected)
+                {
                     return false;
                 }
 
@@ -165,10 +235,21 @@ namespace CSM.Networking
             // We have timed out
             ConnectionMessage = "Could not connect to server, timed out.";
             Log.Warn("Connection timeout!");
+            Status = ClientStatus.PreConnecting;
 
-            // Did not connect
-            Disconnect(); // make sure we are fully disconnected
             return false;
+        }
+
+        /// <summary>
+        ///     Called when the connection was rejected by the server in the ConnectionResultCommand.
+        ///     This also means that the network connection was working properly, so we don't
+        ///     need to try any further network endpoints.
+        /// </summary>
+        public void ConnectRejected()
+        {
+            Status = ClientStatus.Rejected;
+            _netClient.Stop();
+            TransactionHandler.ClearTransactions();
         }
 
         /// <summary>
@@ -199,9 +280,9 @@ namespace CSM.Networking
 
         public void SendToServer(CommandBase message)
         {
-            if (Status == ClientStatus.Disconnected)
+            if (Status == ClientStatus.Disconnected || Status == ClientStatus.PreConnecting)
             {
-                Log.Error("Attempted to send message to server, but the client is disconnected");
+                Log.Error("Attempted to send message to server, but the client is not connected");
                 return;
             }
 
@@ -233,7 +314,7 @@ namespace CSM.Networking
             }
             catch (Exception ex)
             {
-                Log.Error($"Encountered an error while reading command from {peer.EndPoint.Address}:{peer.EndPoint.Port}:", ex);
+                Log.Error("Failed to handle command from server: ", ex);
             }
         }
 
@@ -272,7 +353,7 @@ namespace CSM.Networking
                 ConnectionMessage = "Failed to connect!";
 
             // Log the error message
-            Log.Info($"Disconnected from server. Message: {disconnectInfo.Reason}, Code: {disconnectInfo.SocketErrorCode}");
+            Log.Info($"Disconnected from server. Message: {disconnectInfo.Reason}");
 
             // Log the reason to the console if we are not in 'connecting' state
             if (Status == ClientStatus.Connected)
@@ -298,7 +379,7 @@ namespace CSM.Networking
             }
 
             // If we are connected, disconnect
-            if (Status != ClientStatus.Disconnected && Status != ClientStatus.Connecting)
+            if (Status == ClientStatus.Downloading || Status == ClientStatus.Loading || Status == ClientStatus.Connected)
                 MultiplayerManager.Instance.StopEverything();
 
             // In the case of ClientStatus.Connecting, this also ends the wait loop
@@ -311,7 +392,7 @@ namespace CSM.Networking
         /// </summary>
         private void ListenerOnNetworkErrorEvent(IPEndPoint endpoint, SocketError socketError)
         {
-            Log.Error($"Received an error from {endpoint.Address}:{endpoint.Port}. Code: {socketError}");
+            Log.Error($"Network error: {socketError}");
         }
         
         private void ListenerOnNetworkLatencyUpdateEvent(NetPeer peer, int latency)
@@ -321,11 +402,11 @@ namespace CSM.Networking
 
         public void StartMainMenuEventProcessor()
         {
-            if (MainMenuEventProcessing) return;
+            if (_mainMenuEventProcessing) return;
             new Thread(() =>
             {
-                MainMenuEventProcessing = true;
-                while (MainMenuEventProcessing)
+                _mainMenuEventProcessing = true;
+                while (_mainMenuEventProcessing)
                 {
                     // The threading extension is not yet loaded when at the main menu, so
                     // process the events and go on
@@ -338,7 +419,7 @@ namespace CSM.Networking
 
         public void StopMainMenuEventProcessor()
         {
-            MainMenuEventProcessing = false;
+            _mainMenuEventProcessing = false;
         }
     }
 }

--- a/src/csm/Networking/Client.cs
+++ b/src/csm/Networking/Client.cs
@@ -59,7 +59,7 @@ namespace CSM.Networking
         ///     If the join game panel should show connection troubleshooting
         ///     information.
         /// </summary>
-        public bool ShowTroubleshooting { get; set; } = false;
+        public bool ShowTroubleshooting { get; private set; } = false;
 
         private bool _mainMenuEventProcessing = false;
 
@@ -157,7 +157,7 @@ namespace CSM.Networking
 
             // Register listener and send request to global server
             _netClient.NatPunchModule.Init(natPunchListener);
-            _netClient.NatPunchModule.SendNatIntroduceRequest(new IPEndPoint(IpAddress.GetIpv4(CSM.Settings.ApiServer), 4240), $"client_{resolvedAddress}");
+            _netClient.NatPunchModule.SendNatIntroduceRequest(new IPEndPoint(IpAddress.GetIpv4(CSM.Settings.ApiServer), 4240), resolvedAddress.ToString());
 
             timeoutWatch.Start();
             // Wait for NatPunchModule responses.
@@ -207,13 +207,13 @@ namespace CSM.Networking
             Status = ClientStatus.Connecting;
             ClientId = 0;
 
-            // We need to wait in a loop for 30 seconds (waiting 500ms each time)
+            // We need to wait in a loop for 10 seconds (waiting 250ms each time)
             // while we wait for a successful connection (Status = Connected) or a
             // failed connection (Status = Disconnected).
             Stopwatch waitWatch = new Stopwatch();
             waitWatch.Start();
 
-            // Try connect for 30 seconds
+            // Try connect for 10 seconds
             while (waitWatch.Elapsed < TimeSpan.FromSeconds(10))
             {
                 // If we connect, exit the loop and return true

--- a/src/csm/Networking/IpAddress.cs
+++ b/src/csm/Networking/IpAddress.cs
@@ -74,6 +74,30 @@ namespace CSM.Networking
             }
         }
 
+        public static string GetVPNIpAddress()
+        {
+            try
+            {
+                //Create a new socket
+                using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, 0))
+                {
+                    // Try to connect to random address in 25.0.0.0/8 subnet used by Hamachi
+                    socket.Connect("25.0.0.0", 65530);
+                    // If local address used starts with 25., Hamachi is installed and active
+                    if (socket.LocalEndPoint is IPEndPoint endPoint && endPoint.Address.GetAddressBytes()[0] == 25)
+                    {
+                        return endPoint.Address.ToString();
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+
+            return null;
+        }
+
         public static PortState CheckPort(int port)
         {
             CSMWebClient client = new CSMWebClient();

--- a/src/csm/Networking/IpAddress.cs
+++ b/src/csm/Networking/IpAddress.cs
@@ -1,27 +1,12 @@
 ﻿using System;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
-using System.Text;
 using CSM.API;
 using CSM.Util;
-using LiteNetLib;
 
 namespace CSM.Networking
 {
-    public struct PortState
-    {
-        public string message;
-        public HttpStatusCode status;
-
-        public PortState(string message, HttpStatusCode status)
-        {
-            this.message = message;
-            this.status = status;
-        }
-    }
-
     public static class IpAddress
     {
         public static string GetLocalIpAddress()
@@ -67,7 +52,7 @@ namespace CSM.Networking
                 using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, 0))
                 {
                     // Try to connect to random address in 25.0.0.0/8 subnet used by Hamachi
-                    socket.Connect("25.0.0.0", 65530);
+                    socket.Connect("25.0.0.1", 65530);
                     // If local address used starts with 25., Hamachi is installed and active
                     if (socket.LocalEndPoint is IPEndPoint endPoint && endPoint.Address.GetAddressBytes()[0] == 25)
                     {
@@ -83,45 +68,7 @@ namespace CSM.Networking
             return null;
         }
 
-        public static PortState CheckPort(int port)
-        {
-            CSMWebClient client = new CSMWebClient();
-            try
-            {
-                string answer = client.DownloadString($"http://{CSM.Settings.ApiServer}/api/check?port=" + port);
-                return new PortState(answer, client.StatusCode());
-            }
-            catch (WebException e)
-            {
-                if (e.Response is HttpWebResponse response)
-                {
-                    Encoding encoding = response.CharacterSet != null ? Encoding.GetEncoding(response.CharacterSet) : Encoding.ASCII;
-                    using (Stream stream = response.GetResponseStream())
-                    {
-                        if (stream != null)
-                        {
-                            using (StreamReader reader = new StreamReader(stream, encoding))
-                            {
-                                return new PortState(reader.ReadToEnd(), response.StatusCode);
-                            }
-                        }
-                        else
-                        {
-                            return new PortState(e.Message, HttpStatusCode.InternalServerError);
-                        }
-                    }
-                }
-                else
-                {
-                    return new PortState(e.Message, HttpStatusCode.InternalServerError);
-                }
-            }
-            catch (Exception e)
-            {
-                return new PortState(e.Message, HttpStatusCode.InternalServerError);
-            }
-        }
-
+        // TODO: Cache response
         public static IPAddress GetIpv4(string host)
         {
             return Dns.GetHostEntry(host).AddressList.FirstOrDefault(resolveAddress => resolveAddress.AddressFamily == AddressFamily.InterNetwork);

--- a/src/csm/Networking/MultiplayerManager.cs
+++ b/src/csm/Networking/MultiplayerManager.cs
@@ -82,6 +82,12 @@ namespace CSM.Networking
                 return;
             }
 
+            if (CurrentClient.Status != ClientStatus.Disconnected)
+            {
+                callback.Invoke(false);
+                return;
+            }
+
             new Thread(() =>
             {
                 // Try connect

--- a/src/csm/Networking/Server.cs
+++ b/src/csm/Networking/Server.cs
@@ -121,21 +121,29 @@ namespace CSM.Networking
 
         private void CheckPort()
         {
+            string vpnIp = IpAddress.GetVPNIpAddress();
             PortState state = IpAddress.CheckPort(Config.Port);
             string message;
             bool portOpen = false;
             switch (state.status)
             {
                 case HttpStatusCode.ServiceUnavailable: // Could not reach port
-                    if (automaticSuccess)
+                    if (vpnIp != null)
                     {
                         message =
-                            "It was tried to forward the port automatically, but the server is not reachable from the internet. Manual port forwarding is required.";
+                            "Server is not reachable from the internet. Players can connect over Hamachi using the IP address " +
+                            vpnIp;
+                        portOpen = true; // This is an OK state
+                    }
+                    else if (automaticSuccess)
+                    {
+                        message =
+                                "It was tried to forward the port automatically, but the server is not reachable from the internet. Manual port forwarding is required. See the \"Manage Server\" menu for more info.";
                     }
                     else
                     {
                         message =
-                            "Port could not be forwarded automatically and server is not reachable from the internet. Manual port forwarding is required.";
+                            "Port could not be forwarded automatically and server is not reachable from the internet. Manual port forwarding is required. See the \"Manage Server\" menu for more info.";
                     }
                     break;
                 case HttpStatusCode.OK: // Success
@@ -149,9 +157,20 @@ namespace CSM.Networking
                     {
                         message = "Server is reachable from the internet!";
                     }
+
+                    if (vpnIp != null)
+                    {
+                        message += " Players can also connect over Hamachi, although you don't need it.";
+                    }
                     break;
                 default: // Something failed
-                    if (automaticSuccess)
+                    if (vpnIp != null)
+                    {
+                        message =
+                            "Error while checking server port from the internet. Players should still be able to connect over the Hamachi IP address " +
+                            vpnIp;
+                    }
+                    else if (automaticSuccess)
                     {
                         message = "Port was forwarded automatically, but couldn't be checked due to error: " +
                                   state.message;

--- a/src/csm/Panels/HostGamePanel.cs
+++ b/src/csm/Panels/HostGamePanel.cs
@@ -22,6 +22,7 @@ namespace CSM.Panels
         private UILabel _connectionStatus;
         private UILabel _localIp;
         private UILabel _externalIp;
+        private UILabel _vpnIp;
 
         private UIButton _createButton;
         private UIButton _closeButton;
@@ -43,7 +44,7 @@ namespace CSM.Panels
             color = new Color32(110, 110, 110, 250);
 
             width = 360;
-            height = 580;
+            height = 600;
             relativePosition = PanelManager.GetCenterPosition(this);
 
             // Title Label
@@ -81,9 +82,6 @@ namespace CSM.Panels
             _connectionStatus.textAlignment = UIHorizontalAlignment.Center;
             _connectionStatus.textColor = new Color32(255, 0, 0, 255);
 
-            // Request IP addresses async
-            new Thread(RequestIPs).Start();
-
             // Create Local IP Label
             _localIp = this.CreateLabel("", new Vector2(10, -380));
             _localIp.textAlignment = UIHorizontalAlignment.Center;
@@ -92,12 +90,26 @@ namespace CSM.Panels
             _externalIp = this.CreateLabel("", new Vector2(10, -400));
             _externalIp.textAlignment = UIHorizontalAlignment.Center;
 
+            // Create VPN IP Label
+            _vpnIp = this.CreateLabel("", new Vector2(10, -420));
+            _vpnIp.textAlignment = UIHorizontalAlignment.Center;
+
+            // Request IP addresses async
+            new Thread(RequestIPs).Start();
+            this.eventVisibilityChanged += (component, visible) =>
+            {
+                if (visible)
+                {
+                    new Thread(RequestIPs).Start();
+                }
+            };
+
             // Create Server Button
-            _createButton = this.CreateButton("Create Server", new Vector2(10, -445));
+            _createButton = this.CreateButton("Create Server", new Vector2(10, -465));
             _createButton.eventClick += OnCreateServerClick;
 
             // Close this dialog
-            _closeButton = this.CreateButton("Cancel", new Vector2(10, -515));
+            _closeButton = this.CreateButton("Cancel", new Vector2(10, -535));
             _closeButton.eventClick += (component, param) =>
             {
                 isVisible = false;
@@ -125,6 +137,7 @@ namespace CSM.Panels
             // Request ips
             string sLocalIp = IpAddress.GetLocalIpAddress();
             string sExternalIp = IpAddress.GetExternalIpAddress();
+            string sVpnIp = IpAddress.GetVPNIpAddress();
 
             // Change gui attributes in main thread
             Singleton<SimulationManager>.instance.m_ThreadingWrapper.QueueMainThread(() =>
@@ -134,6 +147,16 @@ namespace CSM.Panels
 
                 _externalIp.textColor = sExternalIp.Equals("Not found") ? new Color32(255, 0, 0, 255) : new Color32(0, 255, 0, 255);
                 _externalIp.text = $"External IP: {sExternalIp}";
+
+                if (sVpnIp != null)
+                {
+                    _vpnIp.textColor = new Color32(0, 255, 0, 255);
+                    _vpnIp.text = $"Hamachi IP: {sVpnIp}";
+                }
+                else
+                {
+                    _vpnIp.text = "";
+                }
             });
         }
 

--- a/src/csm/Panels/JoinGamePanel.cs
+++ b/src/csm/Panels/JoinGamePanel.cs
@@ -22,6 +22,7 @@ namespace CSM.Panels
 
         private UIButton _connectButton;
         private UIButton _closeButton;
+        private UIButton _troubleshootingButton;
 
         private UICheckBox _passwordBox;
         private UICheckBox _rememberBox;
@@ -106,6 +107,15 @@ namespace CSM.Panels
             _connectionStatus.textAlignment = UIHorizontalAlignment.Center;
             _connectionStatus.textColor = new Color32(255, 0, 0, 255);
 
+            _troubleshootingButton = this.CreateButton("?", new Vector2(170, -420), 25, 20);
+            _troubleshootingButton.isVisible = false;
+            _troubleshootingButton.eventClick += (component, param) =>
+            {
+                MessagePanel panel = PanelManager.ShowPanel<MessagePanel>();
+                int.TryParse(_portField.text, out int port);
+                panel.DisplayTroubleshooting(false, port);
+            };
+
             ModCompat.BuildModInfo(this);
 
             eventVisibilityChanged += (comp, visible) =>
@@ -126,6 +136,7 @@ namespace CSM.Panels
 
             _connectionStatus.textColor = new Color32(255, 255, 0, 255);
             _connectionStatus.text = "Connecting...";
+            _troubleshootingButton.isVisible = false;
 
             if (string.IsNullOrEmpty(_portField.text) || string.IsNullOrEmpty(_ipAddressField.text))
             {
@@ -164,6 +175,10 @@ namespace CSM.Panels
                     {
                         _connectionStatus.textColor = new Color32(255, 0, 0, 255);
                         _connectionStatus.text = MultiplayerManager.Instance.CurrentClient.ConnectionMessage;
+                        if (MultiplayerManager.Instance.CurrentClient.ShowTroubleshooting)
+                        {
+                            _troubleshootingButton.isVisible = true;
+                        }
                     }
                     else
                     {

--- a/src/csm/Panels/ManageGamePanel.cs
+++ b/src/csm/Panels/ManageGamePanel.cs
@@ -18,7 +18,7 @@ namespace CSM.Panels
         private UIButton _closeButton;
 
         private int _portVal;
-        private string _localIpVal, _externalIpVal;
+        private string _localIpVal, _externalIpVal, _vpnIpVal;
 
         public override void Start()
         {
@@ -28,8 +28,10 @@ namespace CSM.Panels
             backgroundSprite = "GenericPanel";
             color = new Color32(110, 110, 110, 250);
 
+            _vpnIpVal = IpAddress.GetVPNIpAddress();
+
             width = 360;
-            height = 445;
+            height = _vpnIpVal == null ? 420 : 495;
             relativePosition = PanelManager.GetCenterPosition(this);
 
             // Title Label
@@ -62,6 +64,8 @@ namespace CSM.Panels
             // External IP label
             this.CreateLabel("External IP:", new Vector2(10, -225));
 
+            _portState = this.CreateLabel("", new Vector2(140, -225));
+
             // External IP field
             _externalIpVal = IpAddress.GetExternalIpAddress();
             _externalIpField = this.CreateTextField(_externalIpVal, new Vector2(10, -250));
@@ -70,12 +74,23 @@ namespace CSM.Panels
             {
                 _externalIpField.text = _externalIpVal;
             };
-            
-            _portState = this.CreateLabel("", new Vector2(10, -310));
-            _portState.textAlignment = UIHorizontalAlignment.Center;
+
+            if (_vpnIpVal != null)
+            {
+                // VPN IP label
+                this.CreateLabel("Hamachi IP:", new Vector2(10, -300));
+
+                // VPN IP field
+                UITextField vpnIpField = this.CreateTextField(_vpnIpVal, new Vector2(10, -325));
+                vpnIpField.selectOnFocus = true;
+                vpnIpField.eventTextChanged += (ui, value) =>
+                {
+                    vpnIpField.text = _vpnIpVal;
+                };
+            }
 
             // Close this dialog
-            _closeButton = this.CreateButton("Close", new Vector2(10, -375));
+            _closeButton = this.CreateButton("Close", new Vector2(10, _vpnIpVal == null ? -340 : -415));
             _closeButton.eventClick += (component, param) =>
             {
                 isVisible = false;

--- a/src/csm/Panels/ManageGamePanel.cs
+++ b/src/csm/Panels/ManageGamePanel.cs
@@ -13,9 +13,12 @@ namespace CSM.Panels
         private UITextField _portField;
         private UITextField _localIpField;
         private UITextField _externalIpField;
+        private UITextField _vpnIpField;
+        private UILabel _vpnLabel;
         private UILabel _portState;
 
         private UIButton _closeButton;
+        private UIButton _troubleshootingButton;
 
         private int _portVal;
         private string _localIpVal, _externalIpVal, _vpnIpVal;
@@ -28,10 +31,8 @@ namespace CSM.Panels
             backgroundSprite = "GenericPanel";
             color = new Color32(110, 110, 110, 250);
 
-            _vpnIpVal = IpAddress.GetVPNIpAddress();
-
             width = 360;
-            height = _vpnIpVal == null ? 420 : 495;
+            height = 420;
             relativePosition = PanelManager.GetCenterPosition(this);
 
             // Title Label
@@ -64,30 +65,33 @@ namespace CSM.Panels
             // External IP label
             this.CreateLabel("External IP:", new Vector2(10, -225));
 
-            _portState = this.CreateLabel("", new Vector2(140, -225));
+            _portState = this.CreateLabel("", new Vector2(120, -225));
+            _troubleshootingButton = this.CreateButton("?", new Vector2(325, -225), 25, 20);
+            _troubleshootingButton.isVisible = false;
+            _troubleshootingButton.eventClick += (component, param) =>
+            {
+                MessagePanel panel = PanelManager.ShowPanel<MessagePanel>();
+                panel.DisplayTroubleshooting(true, _portVal, _vpnIpVal != null);
+            };
 
             // External IP field
-            _externalIpVal = IpAddress.GetExternalIpAddress();
-            _externalIpField = this.CreateTextField(_externalIpVal, new Vector2(10, -250));
+            _externalIpField = this.CreateTextField("", new Vector2(10, -250));
             _externalIpField.selectOnFocus = true;
             _externalIpField.eventTextChanged += (ui, value) =>
             {
                 _externalIpField.text = _externalIpVal;
             };
 
-            if (_vpnIpVal != null)
+            // VPN IP label
+            _vpnLabel = this.CreateLabel("Hamachi IP:", new Vector2(10, -300));
+            _vpnLabel.isVisible = false;
+            _vpnIpField = this.CreateTextField("", new Vector2(10, -325));
+            _vpnIpField.selectOnFocus = true;
+            _vpnIpField.isVisible = false;
+            _vpnIpField.eventTextChanged += (ui, value) =>
             {
-                // VPN IP label
-                this.CreateLabel("Hamachi IP:", new Vector2(10, -300));
-
-                // VPN IP field
-                UITextField vpnIpField = this.CreateTextField(_vpnIpVal, new Vector2(10, -325));
-                vpnIpField.selectOnFocus = true;
-                vpnIpField.eventTextChanged += (ui, value) =>
-                {
-                    vpnIpField.text = _vpnIpVal;
-                };
-            }
+                _vpnIpField.text = _vpnIpVal;
+            };
 
             // Close this dialog
             _closeButton = this.CreateButton("Close", new Vector2(10, _vpnIpVal == null ? -340 : -415));
@@ -96,26 +100,49 @@ namespace CSM.Panels
                 isVisible = false;
             };
 
-            new Thread(CheckPort).Start();
+            new Thread(UpdateWindow).Start();
 
             eventVisibilityChanged += (component, visible) =>
             {
                 if (!visible)
                     return;
 
-                _portVal = MultiplayerManager.Instance.CurrentServer.Config.Port;
-                _portField.text = _portVal.ToString();
-                new Thread(CheckPort).Start();
+                new Thread(UpdateWindow).Start();
             };
         }
 
-        private void CheckPort()
+        private void UpdateWindow()
         {
+            _vpnIpVal = IpAddress.GetVPNIpAddress();
+            _localIpVal = IpAddress.GetLocalIpAddress();
+            _externalIpVal = IpAddress.GetExternalIpAddress();
+
             Singleton<SimulationManager>.instance.m_ThreadingWrapper.QueueMainThread(() =>
             {
+                _localIpField.text = _localIpVal;
+                _externalIpField.text = _externalIpVal;
+
                 _portState.text = "Checking port...";
                 _portState.textColor = new Color32(255, 255, 0, 255);
                 _portState.tooltip = "Checking if port is reachable from the internet...";
+                _troubleshootingButton.isVisible = false;
+
+                _portVal = MultiplayerManager.Instance.CurrentServer.Config.Port;
+                _portField.text = _portVal.ToString();
+
+                height = _vpnIpVal == null ? 420 : 495;
+                _closeButton.position = new Vector2(10, _vpnIpVal == null ? -340 : -415);
+                if (_vpnIpVal == null)
+                {
+                    _vpnLabel.isVisible = false;
+                    _vpnIpField.isVisible = false;
+                }
+                else
+                {
+                    _vpnLabel.isVisible = true;
+                    _vpnIpField.isVisible = true;
+                    _vpnIpField.text = _vpnIpVal;
+                }
             });
 
             PortState state = IpAddress.CheckPort(_portVal);
@@ -127,6 +154,7 @@ namespace CSM.Panels
                         _portState.text = "Port is not reachable!";
                         _portState.textColor = new Color32(255, 0, 0, 255);
                         _portState.tooltip = state.message;
+                        _troubleshootingButton.isVisible = true;
                         break;
                     case HttpStatusCode.OK: // Success
                         _portState.text = "Port is reachable!";

--- a/src/csm/Panels/MessagePanel.cs
+++ b/src/csm/Panels/MessagePanel.cs
@@ -257,7 +257,8 @@ namespace CSM.Panels
                 {
                     message += "\n\n   - Since Hamachi seems to be running,\n" +
                                "     players can also connect using your\n" +
-                               "     Hamachi IP.";
+                               "     Hamachi IP.\n" +
+                               "     Also check the Firewall in this case.";
                 }
                 else
                 {

--- a/src/csm/Panels/MessagePanel.cs
+++ b/src/csm/Panels/MessagePanel.cs
@@ -101,6 +101,18 @@ namespace CSM.Panels
             Show(true);
         }
 
+        public void DisplayInvalidApiServer()
+        {
+            SetTitle("Invalid API Server");
+
+            const string message = "The given API server could not be reached.\n" +
+                                   "The URL was not changed.";
+
+            SetMessage(message);
+
+            Show(true);
+        }
+
         private string GetDlcName(DLCPanelNew panel, SteamHelper.DLC dlc)
         {
             string dlcName = panel.FindLocalizedDLCName(dlc);

--- a/src/csm/Panels/MessagePanel.cs
+++ b/src/csm/Panels/MessagePanel.cs
@@ -230,5 +230,73 @@ namespace CSM.Panels
 
             Show(true);
         }
+
+        public void DisplayTroubleshooting(bool isHost, int port=4230, bool hasVpn=false)
+        {
+            SetTitle("Troubleshooting");
+
+            string message;
+
+            if (isHost)
+            {
+                message = "When the port is not reachable, this can have\n" +
+                          "various reasons. You can try the following steps:\n\n" +
+                          "   - Forward the CSM port: You need to\n" +
+                          "     forward the port (" + port + " UDP)\n" +
+                          "     in your router. How this works depends on\n" +
+                          "     the router or internet provider.\n" +
+                          "   -> If it doesn't work yet, you might\n" +
+                          "     need to allow the port through the local\n" +
+                          "     Firewall (e.g. Windows Defender Firewall).\n" +
+                          "     You can find more info on the Internet.\n" +
+                          "   -> You can always check again if the\n" +
+                          "     port is working in the \"Manage Server\" menu.";
+                if (hasVpn)
+                {
+                    message += "\n\n   - Since Hamachi seems to be running,\n" +
+                               "     players can also connect using your\n" +
+                               "     Hamachi IP.";
+                }
+                else
+                {
+                    message += "\n\n   - Alternatively, you can use a VPN solution\n" +
+                               "     like Hamachi or ZeroTier.\n" +
+                               "     Follow the instructions of the respective\n" +
+                               "     tool. Then players can connect using the\n" +
+                               "     displayed IP address of the tool.\n" +
+                               "     You can then ignore any error messages\n" +
+                               "     regarding port forwarding.";
+                }
+            }
+            else
+            {
+                message = "When the \"Failed to connect\" message appears,\n" +
+                          "this can have various reasons. The hosting player\n" +
+                          "can try the following steps:\n\n" +
+                          "- Check if the port is reachable in the\n" +
+                          "  \"Manage Server\" menu\n" +
+                          "  - If yes, make sure you connect using the IP\n" +
+                          "    shown as \"External IP\" in that menu\n\n" +
+                          "- If not, you have two possibilities:\n" +
+                          "  1. Forward the CSM port: The hosting player\n" +
+                          "     needs to forward the port (" + port + " UDP)\n" +
+                          "     in their router. How this works depends on\n" +
+                          "     the router or internet provider.\n" +
+                          "   -> If it doesn't work yet, the host might\n" +
+                          "     need to allow the port through the local\n" +
+                          "     Firewall (e.g. Windows Defender Firewall).\n" +
+                          "     You can find more info on the Internet.\n" +
+                          "   -> The host can always check again if the\n" +
+                          "     port is working in the \"Manage Server\" menu.\n\n" +
+                          "  2. Use a VPN solution like Hamachi or ZeroTier.\n" +
+                          "     Follow the instructions of the respective\n" +
+                          "     tool. Then you can connect using the\n" +
+                          "     displayed IP address of the tool.";
+            }
+
+            SetMessage(message);
+
+            Show(true);
+        }
     }
 }

--- a/src/csm/Panels/PanelManager.cs
+++ b/src/csm/Panels/PanelManager.cs
@@ -7,6 +7,15 @@ namespace CSM.Panels
     {
         private static UIView _uiView;
 
+        public static T GetPanel<T>() where T : UIComponent
+        {
+            if (!_uiView)
+                _uiView = UIView.GetAView();
+
+            string name = typeof(T).Name;
+            return _uiView.FindUIComponent<T>(name);
+        }
+
         public static T TogglePanel<T>() where T : UIComponent
         {
             return ShowPanel<T>(true);
@@ -19,11 +28,7 @@ namespace CSM.Panels
 
         private static T ShowPanel<T>(bool toggle) where T : UIComponent
         {
-            if (!_uiView)
-                _uiView = UIView.GetAView();
-
-            string name = typeof(T).Name;
-            T panel = _uiView.FindUIComponent<T>(name);
+            T panel = GetPanel<T>();
 
             if (panel)
             {
@@ -35,7 +40,7 @@ namespace CSM.Panels
             else
             {
                 panel = (T)_uiView.AddUIComponent(typeof(T));
-                panel.name = name;
+                panel.name = typeof(T).Name;
             }
             panel.Focus();
 

--- a/src/csm/Panels/SettingsPanel.cs
+++ b/src/csm/Panels/SettingsPanel.cs
@@ -1,8 +1,11 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
+using ColossalFramework.Threading;
 using ColossalFramework.UI;
 using CSM.API;
 using CSM.Injections;
 using CSM.Mods;
+using CSM.Util;
 using ICities;
 
 namespace CSM.Panels
@@ -11,7 +14,7 @@ namespace CSM.Panels
     {
         public static void Build(UIHelperBase helper, Settings settings)
         {
-            var chatGroup = helper.AddGroup("Chat");
+            UIHelperBase chatGroup = helper.AddGroup("Chat");
 
             UICheckBox useChirper = (UICheckBox) chatGroup.AddCheckbox("Use Chirper as chat", settings.UseChirper,
                 c => { settings.UseChirper = c; });
@@ -26,7 +29,7 @@ namespace CSM.Panels
                 regularChirper.tooltip = "Disable Chirper mod detected. Chirper chat is not available.";
             }
 
-            var advancedGroup = helper.AddGroup("Advanced");
+            UIHelperBase advancedGroup = helper.AddGroup("Advanced");
 
             UICheckBox cb = (UICheckBox)advancedGroup.AddCheckbox("Enable debug logging", settings.DebugLogging.value,
                 c => {
@@ -35,13 +38,41 @@ namespace CSM.Panels
                 });
             cb.tooltip = "Note: This may cause excessive logging and slow down the game!";
 
-            advancedGroup.AddButton("Show Release Notes", () =>
+            UITextField urlInput = null;
+            urlInput = (UITextField) advancedGroup.AddTextfield("CSM API Server", settings.ApiServer.value, text => {}, url =>
+            {
+                new Thread(() =>
+                {
+                    try
+                    {
+                        new CSMWebClient().DownloadString($"http://{url}/api/version");
+                        settings.ApiServer.value = url;
+                    }
+                    catch (Exception)
+                    {
+                        ThreadHelper.dispatcher.Dispatch(() =>
+                        {
+                            MessagePanel panel = PanelManager.ShowPanel<MessagePanel>();
+                            panel.DisplayInvalidApiServer();
+                            if (urlInput)
+                            {
+                                urlInput.text = settings.ApiServer.value;
+                            }
+                        });
+                    }
+
+                }).Start();
+            });
+            urlInput.width = 400;
+
+            UIHelperBase buttonsGroup = helper.AddGroup("Buttons");
+            buttonsGroup.AddButton("Show Release Notes", () =>
             {
                 MessagePanel panel = PanelManager.ShowPanel<MessagePanel>();
                 panel.DisplayReleaseNotes();
             });
 
-            advancedGroup.AddButton("Check for updates", () =>
+            buttonsGroup.AddButton("Check for updates", () =>
             {
                 new Thread(() => MainMenuHandler.CheckForUpdate(true)).Start();
             });

--- a/src/csm/Settings.cs
+++ b/src/csm/Settings.cs
@@ -16,6 +16,7 @@ namespace CSM
         private const bool DefaultUseChirper = true;
         private const bool DefaultPrintChirperMsgs = false;
         private const string DefaultLastSeenReleaseNotes = "0.0";
+        private const string DefaultApiServer = "api.citiesskylinesmultiplayer.com";
 
         public readonly SavedBool DebugLogging =
             new SavedBool(nameof(DebugLogging), SettingsFile, DefaultDebugLogging, true);
@@ -41,5 +42,8 @@ namespace CSM
 
         public readonly SavedString LastSeenReleaseNotes =
             new SavedString(nameof(LastSeenReleaseNotes), SettingsFile, DefaultLastSeenReleaseNotes, true);
+
+        public readonly SavedString ApiServer =
+            new SavedString(nameof(ApiServer), SettingsFile, DefaultApiServer, true);
     }
 }

--- a/src/gs/CSM.GS.csproj
+++ b/src/gs/CSM.GS.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net7.0</TargetFramework>
+        <RootNamespace>CSM.GS</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+      <PackageReference Include="protobuf-net" Version="2.4.6" />
+      <PackageReference Include="LiteNetLib" Version="0.9.4" />
+    </ItemGroup>
+</Project>

--- a/src/gs/Client.cs
+++ b/src/gs/Client.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Threading;
+using LiteNetLib;
+
+namespace CSM.GS
+{
+    public class Client
+    {
+        private readonly NetManager _netClient;
+        private ClientStatus _status = ClientStatus.Disconnected;
+        private WorkerService _worker;
+
+        public Client(WorkerService worker)
+        {
+            _worker = worker;
+            // Set up network items
+            EventBasedNetListener listener = new();
+            _netClient = new NetManager(listener)
+            {
+                NatPunchEnabled = true,
+                UnconnectedMessagesEnabled = true
+            };
+
+            // Listen to events
+            listener.PeerConnectedEvent += ListenerOnPeerConnectedEvent;
+            listener.PeerDisconnectedEvent += ListenerOnPeerDisconnectedEvent;
+        }
+
+        public bool Connect(IPEndPoint target)
+        {
+            _status = ClientStatus.PreConnecting;
+
+            bool result = _netClient.Start();
+            if (!result)
+            {
+                return false;
+            }
+
+            bool success = SetupHolePunching(target);
+            _netClient.Stop();
+
+            return success;
+        }
+
+        private bool SetupHolePunching(IPEndPoint target)
+        {
+            EventBasedNatPunchListener natPunchListener = new();
+            Stopwatch timeoutWatch = new();
+
+            // Callback on for each possible IP address to connect to the server.
+            // Can potentially be called multiple times (local and public IP address).
+            natPunchListener.NatIntroductionSuccess += (point, _, _) =>
+            {
+                timeoutWatch.Stop();
+
+                if (_status == ClientStatus.PreConnecting)
+                {
+                    bool success = DoConnect(point);
+                    if (!success)
+                    {
+                        _status = ClientStatus.PreConnecting;
+                    }
+                }
+
+                timeoutWatch.Start();
+            };
+
+            // Register listener and send request to global server
+            _netClient.NatPunchModule.Init(natPunchListener);
+            _netClient.NatPunchModule.SendNatIntroduceRequest(new IPEndPoint(_worker.RemoteServerAddress, _worker.ServerPort), target.Address.ToString());
+
+            timeoutWatch.Start();
+            // Wait for NatPunchModule responses.
+            // 5 seconds include only the time waiting for nat punch management.
+            // Connection attempts have their own timeout in the DoConnect method
+            // The waitWatch is paused during an connection attempt.
+            while (_status == ClientStatus.PreConnecting && timeoutWatch.Elapsed < TimeSpan.FromSeconds(5))
+            {
+                _netClient.PollEvents();
+                _netClient.NatPunchModule.PollEvents();
+                Thread.Sleep(50);
+            }
+
+            if (_status == ClientStatus.PreConnecting) // If timeout, try exact given address
+            {
+                bool success = DoConnect(target);
+                if (!success)
+                {
+                    _status = ClientStatus.Disconnected;
+                    return false;
+                }
+
+                return true;
+            }
+
+            return _status == ClientStatus.Connected;
+        }
+
+        private bool DoConnect(IPEndPoint point)
+        {
+            try
+            {
+                _netClient.Connect(point, "CSM");
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+
+            // Start processing networking
+            _status = ClientStatus.Connecting;
+
+            Stopwatch waitWatch = new();
+            waitWatch.Start();
+
+            // Try connect for 10 seconds
+            while (waitWatch.Elapsed < TimeSpan.FromSeconds(10))
+            {
+                _netClient.PollEvents();
+                // If we connect, exit the loop and return true
+                if (_status == ClientStatus.Connected)
+                {
+                    return true;
+                }
+
+                // The client cannot connect for some reason
+                if (_status == ClientStatus.Disconnected)
+                {
+                    return false;
+                }
+                // Wait 250ms
+                Thread.Sleep(100);
+            }
+            return false;
+        }
+
+        private void ListenerOnPeerConnectedEvent(NetPeer peer)
+        {
+            _status = ClientStatus.Connected;
+        }
+
+        private void ListenerOnPeerDisconnectedEvent(NetPeer peer, DisconnectInfo disconnectInfo)
+        {
+            _status = ClientStatus.Disconnected;
+        }
+    }
+}

--- a/src/gs/ClientStatus.cs
+++ b/src/gs/ClientStatus.cs
@@ -1,0 +1,32 @@
+﻿namespace CSM.GS
+{
+    /// <summary>
+    ///     Different client connection states
+    /// </summary>
+    public enum ClientStatus
+    {
+        /// <summary>
+        ///     The client is not connected to a server
+        ///     and will not process any network events.
+        /// </summary>
+        Disconnected,
+
+        /// <summary>
+        ///     Before starting to actually connect, the global server
+        ///     is queried and NAT punchthrough is attempted.
+        /// </summary>
+        PreConnecting,
+
+        /// <summary>
+        ///     The client is trying to connect to the server, this phase
+        ///     can take up to 30 seconds.
+        /// </summary>
+        Connecting,
+
+        /// <summary>
+        ///     The client is connected to the server and is
+        ///     transmitting information.
+        /// </summary>
+        Connected
+    }
+}

--- a/src/gs/Commands/ApiCommand.cs
+++ b/src/gs/Commands/ApiCommand.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using CSM.GS.Commands.Data.ApiServer;
+using CSM.GS.Commands.Handler.ApiServer;
+using CSM.GS.Helpers;
+using ProtoBuf.Meta;
+
+namespace CSM.GS.Commands
+{
+    public class ApiCommand
+    {
+        public static ApiCommand Instance;
+
+        private readonly Dictionary<Type, ApiCommandHandler> _apiCmdMapping = new();
+
+        public TypeModel ApiModel { get; private set; }
+
+        /// <summary>
+        ///     This method is used to get the handler of given API command.
+        /// </summary>
+        /// <param name="commandType">The Type of a ApiCommandBase subclass.</param>
+        /// <returns>The handler for the given command.</returns>
+        public ApiCommandHandler GetApiCommandHandler(Type commandType)
+        {
+            _apiCmdMapping.TryGetValue(commandType, out ApiCommandHandler handler);
+            return handler;
+        }
+
+        /// <summary>
+        ///     Serializes the command into a byte array for sending over the network.
+        /// </summary>
+        /// <returns>A byte array containing the message.</returns>
+        public static byte[] Serialize(ApiCommandBase cmd)
+        {
+            using MemoryStream stream = new();
+            Instance.ApiModel.Serialize(stream, cmd);
+            return stream.ToArray();
+        }
+
+        public void RefreshModel()
+        {
+            _apiCmdMapping.Clear();
+            try
+            {
+                // First, setup protocol model for the API server:
+                Type[] apiHandlers = AssemblyHelper.FindClassesInAssembly(typeof(ApiCommandHandler)).ToArray();
+                // Create a protobuf model
+                RuntimeTypeModel apiModel = RuntimeTypeModel.Create();
+                // Add base command to the protobuf model with all attributes
+                apiModel.Add(typeof(ApiCommandBase), true);
+                MetaType baseApiCmd = apiModel[typeof(ApiCommandBase)];
+
+                // Lowest id of the subclasses
+                int id = 100;
+
+                // Create instances of the handlers, initialize mappings and register command subclasses in the protobuf model
+                foreach (Type type in apiHandlers)
+                {
+                    ApiCommandHandler handler = (ApiCommandHandler)Activator.CreateInstance(type);
+                    _apiCmdMapping.Add(handler.GetDataType(), handler);
+
+                    // Add subtype to the protobuf model with all attributes
+                    baseApiCmd.AddSubType(id, handler.GetDataType());
+                    apiModel.Add(handler.GetDataType(), true);
+
+                    id++;
+                }
+
+                // Compile the protobuf model
+                apiModel.CompileInPlace();
+
+                ApiModel = apiModel;
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+        }
+    }
+}

--- a/src/gs/Commands/CommandReceiver.cs
+++ b/src/gs/Commands/CommandReceiver.cs
@@ -1,0 +1,41 @@
+﻿using System.IO;
+using System.Net;
+using CSM.GS.Commands.Data.ApiServer;
+using CSM.GS.Commands.Handler.ApiServer;
+using LiteNetLib;
+
+namespace CSM.GS.Commands
+{
+    public static class CommandReceiver
+    {
+        /// <summary>
+        ///     This method is used to parse an incoming message from the API server
+        ///     and execute the appropriate action.
+        /// </summary>
+        /// <param name="endPoint">The sending IP end point</param>
+        /// <param name="reader">The incoming packet including the command type byte.</param>
+        /// <param name="service">The worker service instance</param>
+        public static void Parse(WorkerService service, IPEndPoint endPoint, NetPacketReader reader)
+        {
+            ApiCommandBase cmd = Deserialize(reader.GetRemainingBytes());
+
+
+            ApiCommandHandler handler = ApiCommand.Instance.GetApiCommandHandler(cmd.GetType());
+
+            handler?.Parse(service, endPoint, cmd);
+        }
+
+        /// <summary>
+        ///     Deserialize the command from a byte array.
+        /// </summary>
+        /// <param name="message">A byte array of the message</param>
+        /// <returns>The deserialized command.</returns>
+        private static ApiCommandBase Deserialize(byte[] message)
+        {
+            using MemoryStream stream = new(message);
+            ApiCommandBase result = (ApiCommandBase)ApiCommand.Instance.ApiModel.Deserialize(stream, null, typeof(ApiCommandBase));
+
+            return result;
+        }
+    }
+}

--- a/src/gs/Commands/Data/ApiServer/ApiCommandBase.cs
+++ b/src/gs/Commands/Data/ApiServer/ApiCommandBase.cs
@@ -1,0 +1,10 @@
+using ProtoBuf;
+
+namespace CSM.GS.Commands.Data.ApiServer
+{
+    [ProtoContract]
+    public abstract class ApiCommandBase
+    {
+
+    }
+}

--- a/src/gs/Commands/Data/ApiServer/PortCheckRequestCommand.cs
+++ b/src/gs/Commands/Data/ApiServer/PortCheckRequestCommand.cs
@@ -1,0 +1,19 @@
+﻿using ProtoBuf;
+
+namespace CSM.GS.Commands.Data.ApiServer
+{
+    /// <summary>
+    ///     Request the global server to check the given port for connectivity.
+    /// </summary>
+    /// Sent by:
+    /// - Server
+    [ProtoContract]
+    public class PortCheckRequestCommand : ApiCommandBase
+    {
+        /// <summary>
+        ///     The port to check.
+        /// </summary>
+        [ProtoMember(1)]
+        public int Port { get; set; }
+    }
+}

--- a/src/gs/Commands/Data/ApiServer/PortCheckResultCommand.cs
+++ b/src/gs/Commands/Data/ApiServer/PortCheckResultCommand.cs
@@ -1,0 +1,32 @@
+﻿using ProtoBuf;
+
+namespace CSM.GS.Commands.Data.ApiServer
+{
+    /// <summary>
+    ///     Response of the global server to check the port
+    /// </summary>
+    /// Sent by:
+    /// - Global Server
+    [ProtoContract]
+    public class PortCheckResultCommand : ApiCommandBase
+    {
+        /// <summary>
+        ///     The determined state of the checked port.
+        /// </summary>
+        [ProtoMember(1)]
+        public PortCheckResult State { get; set; }
+
+        /// <summary>
+        ///     The error message in case the port check failed.
+        /// </summary>
+        [ProtoMember(2)]
+        public string Message { get; set; }
+    }
+
+    public enum PortCheckResult
+    {
+        Reachable,
+        Unreachable,
+        Error
+    }
+}

--- a/src/gs/Commands/Data/ApiServer/ServerRegistrationCommand.cs
+++ b/src/gs/Commands/Data/ApiServer/ServerRegistrationCommand.cs
@@ -1,0 +1,31 @@
+using ProtoBuf;
+
+namespace CSM.GS.Commands.Data.ApiServer
+{
+    /// <summary>
+    ///     Registers the game server on the API server to enable NAT hole punching.
+    /// </summary>
+    /// Sent by:
+    /// - Server
+    [ProtoContract]
+    public class ServerRegistrationCommand : ApiCommandBase
+    {
+        /// <summary>
+        ///     The server token to register.
+        /// </summary>
+        [ProtoMember(1)]
+        public string Token { get; set; }
+
+        /// <summary>
+        ///     The server's IP address in the local network.
+        /// </summary>
+        [ProtoMember(2)]
+        public string LocalIp { get; set; }
+
+        /// <summary>
+        ///     The configured local port.
+        /// </summary>
+        [ProtoMember(3)]
+        public int LocalPort { get; set; }
+    }
+}

--- a/src/gs/Commands/Handler/ApiServer/ApiCommandHandler.cs
+++ b/src/gs/Commands/Handler/ApiServer/ApiCommandHandler.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Net;
+using CSM.GS.Commands.Data.ApiServer;
+
+namespace CSM.GS.Commands.Handler.ApiServer
+{
+    public abstract class ApiCommandHandler
+    {
+        public abstract Type GetDataType();
+
+        public abstract void Parse(WorkerService worker, IPEndPoint sender, ApiCommandBase message);
+    }
+
+    public abstract class ApiCommandHandler<C> : ApiCommandHandler where C : ApiCommandBase
+    {
+        protected WorkerService worker;
+        protected IPEndPoint sender;
+
+        protected abstract void Handle(C command);
+
+        public override Type GetDataType()
+        {
+            return typeof(C);
+        }
+
+        public override void Parse(WorkerService worker, IPEndPoint sender, ApiCommandBase command)
+        {
+            this.worker = worker;
+            this.sender = sender;
+            Handle((C) command);
+        }
+    }
+}

--- a/src/gs/Commands/Handler/ApiServer/PortCheckRequestHandler.cs
+++ b/src/gs/Commands/Handler/ApiServer/PortCheckRequestHandler.cs
@@ -1,0 +1,26 @@
+﻿using System.Net;
+using System.Threading;
+using CSM.GS.Commands.Data.ApiServer;
+
+namespace CSM.GS.Commands.Handler.ApiServer
+{
+    public class PortCheckRequestHandler : ApiCommandHandler<PortCheckRequestCommand>
+    {
+        protected override void Handle(PortCheckRequestCommand command)
+        {
+            IPEndPoint endPoint = new(sender.Address, command.Port);
+            new Thread(() =>
+            {
+                bool result = new Client(worker).Connect(endPoint);
+                worker.QueueAction(() =>
+                {
+                    worker.SendToServer(sender, new PortCheckResultCommand
+                    {
+                        State = result ? PortCheckResult.Reachable : PortCheckResult.Unreachable,
+                        Message = null
+                    });
+                });
+            }).Start();
+        }
+    }
+}

--- a/src/gs/Commands/Handler/ApiServer/PortCheckResultHandler.cs
+++ b/src/gs/Commands/Handler/ApiServer/PortCheckResultHandler.cs
@@ -1,0 +1,12 @@
+﻿using CSM.GS.Commands.Data.ApiServer;
+
+namespace CSM.GS.Commands.Handler.ApiServer
+{
+    public class PortCheckResultHandler : ApiCommandHandler<PortCheckResultCommand>
+    {
+        protected override void Handle(PortCheckResultCommand command)
+        {
+            // Do nothing, this is a packet for the CSM server
+        }
+    }
+}

--- a/src/gs/Commands/Handler/ApiServer/ServerRegistrationHandler.cs
+++ b/src/gs/Commands/Handler/ApiServer/ServerRegistrationHandler.cs
@@ -1,0 +1,13 @@
+using System.Net;
+using CSM.GS.Commands.Data.ApiServer;
+
+namespace CSM.GS.Commands.Handler.ApiServer
+{
+    public class ServerRegistrationHandler : ApiCommandHandler<ServerRegistrationCommand>
+    {
+        protected override void Handle(ServerRegistrationCommand command)
+        {
+            worker.RegisterServer(sender, new IPEndPoint(IPAddress.Parse(command.LocalIp), command.LocalPort), command.Token);
+        }
+    }
+}

--- a/src/gs/Dockerfile
+++ b/src/gs/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build-env
+WORKDIR /app
+
+COPY *.csproj ./
+RUN dotnet restore
+
+COPY . ./
+RUN dotnet publish -c Release -o out
+
+FROM mcr.microsoft.com/dotnet/runtime:7.0
+WORKDIR /app
+COPY --from=build-env /app/out .
+ENTRYPOINT ["dotnet", "CSM.GS.dll"]

--- a/src/gs/Helpers/AssemblyHelper.cs
+++ b/src/gs/Helpers/AssemblyHelper.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace CSM.GS.Helpers
+{
+    public static class AssemblyHelper
+    {
+        /// <summary>
+        /// Searches CSM API server Assembly in the current AppDomain for class definitions that implement the given Type.
+        /// </summary>
+        public static IEnumerable<Type> FindClassesInAssembly(Type typeToSearchFor)
+        {
+            // Only use own assembly, others have to be registered as mods
+            Assembly assembly = typeof(AssemblyHelper).Assembly;
+
+            IEnumerable<Type> handlers = FindImplementationsInAssembly(assembly, typeToSearchFor);
+            foreach (Type handler in handlers)
+            {
+                yield return handler;
+            }
+        }
+
+        /// <summary>
+        /// Finds all the implementations of the given type in the given Assembly.
+        /// </summary>
+        private static IEnumerable<Type> FindImplementationsInAssembly(Assembly assembly, Type typeToSearchFor)
+        {
+            Type[] types = Type.EmptyTypes;
+            try
+            {
+                types = assembly.GetTypes();
+            }
+            catch
+            {
+                // ignored
+            }
+
+            foreach (Type type in types)
+            {
+                bool isValid = false;
+                try
+                {
+                    isValid = typeToSearchFor.IsAssignableFrom(type) && type.IsClass && !type.IsAbstract;
+                }
+                catch
+                {
+                    // ignored
+                }
+
+                if (isValid)
+                {
+                    yield return type;
+                }
+            }
+        }
+    }
+}

--- a/src/gs/Program.cs
+++ b/src/gs/Program.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace CSM.GS
+{
+    /// <summary>
+    ///     This is the UDP hole punching server, the clients will connect
+    ///     to this server to setup the correct ports
+    /// </summary>
+    public static class Program
+    {
+        public static void Main(string[] args) => CreateHostBuilder(args).Build().Run();
+
+        private static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration((_, config) =>
+                {
+                    config.AddJsonFile("settings.json", true, true);
+                    config.AddEnvironmentVariables("GS_");
+                    config.AddCommandLine(args);
+                })
+                .ConfigureLogging(logging =>
+                {
+                    logging.ClearProviders();
+                    logging.AddConsole();
+                })
+                .ConfigureServices((_, services) =>
+                    services.AddHostedService<WorkerService>());
+    }
+}

--- a/src/gs/Server.cs
+++ b/src/gs/Server.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Net;
+
+namespace CSM.GS
+{
+    /// <summary>
+    ///     Represents a game server connected to the current CSM GS.
+    ///     As long as the game server is running, this object will stay
+    ///     in memory.
+    /// </summary>
+    public class Server
+    {
+        /// <summary>
+        ///     A unique token identifying this server (so the public IP address does
+        ///     not need to be displayed)
+        /// </summary>
+        public string Token { get; }
+
+        /// <summary>
+        ///     The internal IP address (behind the NAT) of the server, also known
+        ///     as the local or private IP.
+        /// </summary>
+        public IPEndPoint InternalAddress { get; }
+
+        /// <summary>
+        ///     The public IP address (in front of the NAT) of the server, also
+        ///     known as the public ip address (what the client will connect to)
+        /// </summary>
+        public IPEndPoint ExternalAddress { get; }
+
+        /// <summary>
+        ///     Time of the last ping of the server, used to determine if the server
+        ///     is still running.
+        /// </summary>
+        public DateTime LastPing { get; }
+
+        public Server(IPEndPoint internalAddress, IPEndPoint externalAddress, string token)
+        {
+            LastPing = DateTime.Now;
+            Token = token;
+            InternalAddress = internalAddress;
+            ExternalAddress = externalAddress;
+        }
+    }
+}

--- a/src/gs/WorkerService.cs
+++ b/src/gs/WorkerService.cs
@@ -1,0 +1,217 @@
+using LiteNetLib;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using CSM.GS.Commands;
+using CSM.GS.Commands.Data.ApiServer;
+using Microsoft.Extensions.Configuration;
+
+namespace CSM.GS
+{
+    /// <summary>
+    ///     This background service a UDP server which matches
+    ///     servers and clients up via NAT hole punching.
+    ///
+    ///     TODO:
+    ///         - Let clients connect using a token instead of an IP address
+    /// </summary>
+    public class WorkerService : BackgroundService, INatPunchListener
+    {
+        // Constants
+        public int ServerPort => int.TryParse(_config.GetSection("PORT").Value, out int val) ? val : 4240;
+        private int ServerTick => int.TryParse(_config.GetSection("TICK").Value, out int val) ? val : 10;
+        private TimeSpan KickTime => TimeSpan.FromSeconds(int.TryParse(_config.GetSection("KICK_TIME").Value, out int val) ? val : 15);
+        private IPAddress LocalServerAddress => IPAddress.TryParse(_config.GetSection("LOCAL_IP").Value, out IPAddress val) ? val : IPAddress.Parse("127.0.0.1");
+        public IPAddress RemoteServerAddress => IPAddress.TryParse(_config.GetSection("SERVER_IP").Value, out IPAddress val) ? val : IPAddress.Parse("127.0.0.1");
+
+        private NetManager _puncher;
+        private readonly ILogger _logger;
+        private readonly IConfiguration _config;
+
+        private readonly Dictionary<IPAddress, Server> _gameServers = new();
+        private readonly List<IPAddress> _serversToRemove = new();
+
+        private readonly ConcurrentQueue<Action> _tasks = new();
+
+        private readonly Type _responsePacketType;
+        private readonly object _responsePacket;
+        private readonly MethodInfo _responsePacketSend;
+
+        public WorkerService(ILogger<WorkerService> logger, IConfiguration config)
+        {
+            _logger = logger;
+            _config = config;
+            ApiCommand.Instance = new ApiCommand();
+            ApiCommand.Instance.RefreshModel();
+
+            _responsePacketType = typeof(NatPunchModule).GetNestedType("NatIntroduceResponsePacket", BindingFlags.NonPublic);
+            if (_responsePacketType != null)
+            {
+                _responsePacket = Activator.CreateInstance(_responsePacketType);
+                MethodInfo send =
+                    typeof(NatPunchModule).GetMethod("Send", BindingFlags.NonPublic | BindingFlags.Instance);
+                if (send != null) _responsePacketSend = send.MakeGenericMethod(_responsePacketType);
+            }
+        }
+
+        protected override Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            EventBasedNetListener netListener = new();
+
+            // Here we update the last contact time in the list of internal servers
+            netListener.NetworkReceiveUnconnectedEvent += (point, reader, type) =>
+            {
+                if (type != UnconnectedMessageType.BasicMessage)
+                    return;
+
+                try
+                {
+                    CommandReceiver.Parse(this, point, reader);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Encountered an error while reading command from {Address}:{Port}:", Anonymize(point.Address), point.Port);
+                }
+            };
+
+            _puncher = new NetManager(netListener);
+
+            _puncher.Start(ServerPort);
+            _puncher.NatPunchEnabled = true;
+            _puncher.UnconnectedMessagesEnabled = true;
+            _puncher.NatPunchModule.Init(this);
+
+            _logger.LogInformation("Starting NAT Relay Server...");
+
+            // Loop
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                DateTime now = DateTime.Now;
+
+                // Run queued actions in this thread
+                while (_tasks.TryDequeue(out Action action))
+                    action.Invoke();
+
+                _puncher.NatPunchModule.PollEvents();
+                _puncher.PollEvents();
+
+                // Check old servers, if a server has been waiting for longer than
+                // "KickTime", they need to be removed from the server list
+                foreach (KeyValuePair<IPAddress, Server> server in _gameServers)
+                {
+                    if (now - server.Value.LastPing > KickTime)
+                    {
+                        _serversToRemove.Add(server.Key);
+                    }
+                }
+
+                // Now actually remove servers that are due for removal
+                foreach (IPAddress ip in _serversToRemove)
+                {
+                    _logger.LogInformation("[{ExternalAddress}] Server has disconnected, removing from internal dictionary...", Anonymize(ip));
+                    _gameServers.Remove(ip);
+                }
+
+                _serversToRemove.Clear();
+
+                Thread.Sleep(ServerTick);
+            }
+
+            _logger.LogInformation("Stopping NAT Relay Server...");
+
+            _puncher.Stop();
+            return Task.CompletedTask;
+        }
+
+        public void OnNatIntroductionRequest(IPEndPoint localEndPoint, IPEndPoint remoteEndPoint, string token)
+        {
+            // If this is the local IP of this server, we are connecting from the port check client
+            bool isFromPortTester = Equals(remoteEndPoint.Address, LocalServerAddress);
+            if (isFromPortTester)
+            {
+                remoteEndPoint.Address = RemoteServerAddress;
+            }
+
+            IPAddress serverIp;
+            try
+            {
+                serverIp = IPAddress.Parse(token);
+            }
+            catch (FormatException)
+            {
+                return;
+            }
+
+            if (_gameServers.TryGetValue(serverIp, out Server server))
+            {
+                // At this point, we have access to the client and server, we can now introduce them
+                _logger.LogInformation("Introduction -> Host: {HostingInternalAddress} {HostExternalAddress}, Client: {ClientInternalAddress} {ClientExternalAddress}", Anonymize(server.InternalAddress), Anonymize(server.ExternalAddress), Anonymize(localEndPoint), Anonymize(remoteEndPoint));
+
+                // The following is a reproduction of NatPunchModule::NatIntroduce, but changes the client remote address if it comes from our port checker
+                _responsePacketType?.GetProperty("Token")?.SetValue(_responsePacket, token);
+
+                _responsePacketType?.GetProperty("Internal")?.SetValue(_responsePacket, server.InternalAddress);
+                _responsePacketType?.GetProperty("External")?.SetValue(_responsePacket, server.ExternalAddress);
+                _responsePacketSend?.Invoke(_puncher.NatPunchModule, new [] {_responsePacket, isFromPortTester ? localEndPoint : remoteEndPoint});
+
+                _responsePacketType?.GetProperty("Internal")?.SetValue(_responsePacket, localEndPoint);
+                _responsePacketType?.GetProperty("External")?.SetValue(_responsePacket, remoteEndPoint);
+                _responsePacketSend?.Invoke(_puncher.NatPunchModule, new [] {_responsePacket, server.ExternalAddress});
+            }
+            else
+            {
+                _logger.LogInformation("Server not found, ignoring...");
+            }
+        }
+
+        public void OnNatIntroductionSuccess(IPEndPoint targetEndPoint, NatAddressType type, string token)
+        {
+            // Ignore as we are the API server
+        }
+
+        public void RegisterServer(IPEndPoint remoteEndPoint, IPEndPoint localEndPoint, string token)
+        {
+            if (!_gameServers.ContainsKey(remoteEndPoint.Address))
+            {
+                _logger.LogInformation("[{ExternalAddress}] Registered Server: Internal Address={InternalAddress} Token={Token}", Anonymize(remoteEndPoint), Anonymize(localEndPoint), token);
+            }
+            // Always create new server entry, so that port numbers and the token are updated
+            _gameServers[remoteEndPoint.Address] = new Server(localEndPoint, remoteEndPoint, token);
+        }
+
+        public void SendToServer(IPEndPoint server, ApiCommandBase command)
+        {
+            byte[] data = ApiCommand.Serialize(command);
+            _puncher.SendUnconnectedMessage(data, server);
+        }
+
+        private static string Anonymize(IPEndPoint endpoint)
+        {
+            return Anonymize(endpoint.Address) + ":" + endpoint.Port;
+        }
+
+        private static string Anonymize(IPAddress address)
+        {
+            string[] parts = address.ToString().Split('.');
+            if (parts.Length == 4)
+            {
+                return parts[0] + '.' + parts[1] + ".x.x";
+            }
+            else
+            {
+                return address.ToString();
+            }
+        }
+
+        public void QueueAction(Action action)
+        {
+            _tasks.Enqueue(action);
+        }
+    }
+}


### PR DESCRIPTION
When joining a server, the implementation will now
1. Request the hole punching server to initiate the NAT hole punching
2. The hole punching server returns a registered ip address and instructs the CSM server to punch a hole
3. LiteNetLib performs the hole punching and tries to verify a working connection
4. Our implementation tries to use the returned IP address to connect to the CSM server
5. If unsuccessful or server is not known on the hole punching server, the given IP address is used to connect directly (e.g. for a local network or Hamachi)

The hole punching server was improved slightly, and is now included in this repository.

The server is currently running on api.citiesskylinesmultiplayer.com port 4240 (only IPv4 for now).

An additional feature introduced with this patch is the ability to change the API server through a mod setting (if someone wants to host their own setup).
