### PR TITLE
Update to Cities 1.15.1

### DIFF
--- a/src/csm/Commands/Data/Internal/ConnectionRequestCommand.cs
+++ b/src/csm/Commands/Data/Internal/ConnectionRequestCommand.cs
@@ -50,15 +50,21 @@ namespace CSM.Commands.Data.Internal
         public string GameVersion { get; set; }
 
         /// <summary>
-        ///     BitMask containing the installed DLCs of the client
+        ///     BitMask containing the installed expansions of the client
         /// </summary>
         [ProtoMember(6)]
-        public SteamHelper.DLC_BitMask DLCBitMask { get; set; }
+        public SteamHelper.ExpansionBitMask ExpansionBitMask { get; set; }
+
+        /// <summary>
+        ///     BitMask containing the installed modder packs of the client
+        /// </summary>
+        [ProtoMember(7)]
+        public SteamHelper.ModderPackBitMask ModderPackBitMask { get; set; }
         
         /// <summary>
         ///     A list of mods with multiplayer support that were loaded.
         /// </summary>
-        [ProtoMember(7)]
+        [ProtoMember(8)]
         public List<string> Mods { get; set; }
     }
 }

--- a/src/csm/Commands/Data/Internal/ConnectionResultCommand.cs
+++ b/src/csm/Commands/Data/Internal/ConnectionResultCommand.cs
@@ -34,17 +34,24 @@ namespace CSM.Commands.Data.Internal
         public int ClientId { get; set; }
 
         /// <summary>
-        ///     Contains the DLC bit mask of the server for comparison,
+        ///     Contains the Expansion DLC bit mask of the server for comparison,
         ///     when DLCs of the client and server don't match.
         /// </summary>
         [ProtoMember(4)]
-        public SteamHelper.DLC_BitMask DLCBitMask { get; set; }
+        public SteamHelper.ExpansionBitMask ExpansionBitMask { get; set; }
+
+        /// <summary>
+        ///     Contains the Modder Pack DLC bit mask of the server for comparison,
+        ///     when DLCs of the client and server don't match.
+        /// </summary>
+        [ProtoMember(5)]
+        public SteamHelper.ModderPackBitMask ModderPackBitMask { get; set; }
         
         /// <summary>
         ///     Contains the list of loaded mod connections for comparison,
         ///     when mods of the client and server don't match.
         /// </summary>
-        [ProtoMember(5)]
+        [ProtoMember(6)]
         public List<string> Mods { get; set; }
     }
 }

--- a/src/csm/Commands/Handler/Internal/ConnectionRequestHandler.cs
+++ b/src/csm/Commands/Handler/Internal/ConnectionRequestHandler.cs
@@ -95,16 +95,30 @@ namespace CSM.Commands.Handler.Internal
                 }
             }
 
-            SteamHelper.DLC_BitMask dlcMask = DLCHelper.GetOwnedDLCs();
+            SteamHelper.ExpansionBitMask expansionDlcMask = DLCHelper.GetOwnedExpansions();
+            SteamHelper.ModderPackBitMask modderPackDlcMask = DLCHelper.GetOwnedModderPacks();
             // Check both client have the same DLCs enabled
-            if (!command.DLCBitMask.Equals(dlcMask))
+            if (!command.ExpansionBitMask.Equals(expansionDlcMask))
             {
-                Log.Info($"Connection rejected: DLC bit mask {command.DLCBitMask} (client) and {dlcMask} (server) differ.");
+                Log.Info($"Connection rejected: DLC bit mask {command.ExpansionBitMask} + {command.ModderPackBitMask} (client) and {expansionDlcMask} + {modderPackDlcMask} (server) differ.");
                 CommandInternal.Instance.SendToClient(peer, new ConnectionResultCommand
                 {
                     Success = false,
                     Reason = "DLCs don't match",
-                    DLCBitMask = dlcMask
+                    ExpansionBitMask = expansionDlcMask,
+                    ModderPackBitMask = modderPackDlcMask
+                });
+                return;
+            }
+            if (!command.ModderPackBitMask.Equals(modderPackDlcMask))
+            {
+                Log.Info($"Connection rejected: DLC bit mask {command.ExpansionBitMask} + {command.ModderPackBitMask} (client) and {expansionDlcMask} + {modderPackDlcMask} (server) differ.");
+                CommandInternal.Instance.SendToClient(peer, new ConnectionResultCommand
+                {
+                    Success = false,
+                    Reason = "DLCs don't match",
+                    ExpansionBitMask = expansionDlcMask,
+                    ModderPackBitMask = modderPackDlcMask
                 });
                 return;
             }

--- a/src/csm/Commands/Handler/Internal/ConnectionResultHandler.cs
+++ b/src/csm/Commands/Handler/Internal/ConnectionResultHandler.cs
@@ -42,7 +42,7 @@ namespace CSM.Commands.Handler.Internal
                 MultiplayerManager.Instance.CurrentClient.Disconnect();
                 if (command.Reason.Contains("DLC")) // No other way to detect if we should display the box
                 {
-                    DLCHelper.DLCComparison compare = DLCHelper.Compare(command.DLCBitMask, DLCHelper.GetOwnedDLCs());
+                    DLCHelper.DLCComparison compare = DLCHelper.Compare(command.ExpansionBitMask, DLCHelper.GetOwnedExpansions(), command.ModderPackBitMask, DLCHelper.GetOwnedModderPacks());
 
                     ThreadHelper.dispatcher.Dispatch(() =>
                     {

--- a/src/csm/Helpers/DLCHelper.cs
+++ b/src/csm/Helpers/DLCHelper.cs
@@ -2,34 +2,33 @@ namespace CSM.Helpers
 {
     public static class DLCHelper
     {
-        private const SteamHelper.DLC_BitMask RadioStations = SteamHelper.DLC_BitMask.RadioStation1 |
-                                                              SteamHelper.DLC_BitMask.RadioStation2;
-                                                              // Only need to check 1 and 2 as others are
-                                                              // in BitMask2 which we ignore completely.
-
-        private static SteamHelper.DLC_BitMask RemoveRadioStations(SteamHelper.DLC_BitMask bitmask)
+        public static SteamHelper.ExpansionBitMask GetOwnedExpansions()
         {
-            return bitmask & ~RadioStations;
+            return SteamHelper.GetOwnedExpansionMask();
         }
 
-        public static SteamHelper.DLC_BitMask GetOwnedDLCs()
+        public static SteamHelper.ModderPackBitMask GetOwnedModderPacks()
         {
-            return RemoveRadioStations(SteamHelper.GetOwnedDLCMask());
+            return SteamHelper.GetOwnedModderPackMask();
         }
 
-        public static DLCComparison Compare(SteamHelper.DLC_BitMask server, SteamHelper.DLC_BitMask client)
+        public static DLCComparison Compare(SteamHelper.ExpansionBitMask serverExpansion, SteamHelper.ExpansionBitMask clientExpansion, SteamHelper.ModderPackBitMask serverModderPack, SteamHelper.ModderPackBitMask clientModderPack)
         {
             return new DLCComparison
             {
-                ServerMissing = ~server & client,
-                ClientMissing = server & ~client,
+                ServerMissingExpansions = ~serverExpansion & clientExpansion,
+                ClientMissingExpansions = serverExpansion & ~clientExpansion,
+                ServerMissingModderPack = ~serverModderPack & clientModderPack,
+                ClientMissingModderPack = serverModderPack & ~clientModderPack,
             };
         }
 
         public class DLCComparison
         {
-            public SteamHelper.DLC_BitMask ServerMissing { get; set; }
-            public SteamHelper.DLC_BitMask ClientMissing { get; set; }
+            public SteamHelper.ExpansionBitMask ServerMissingExpansions { get; set; }
+            public SteamHelper.ExpansionBitMask ClientMissingExpansions { get; set; }
+            public SteamHelper.ModderPackBitMask ServerMissingModderPack { get; set; }
+            public SteamHelper.ModderPackBitMask ClientMissingModderPack { get; set; }
         }
     }
 }

--- a/src/csm/Injections/PauseMenuHandler.cs
+++ b/src/csm/Injections/PauseMenuHandler.cs
@@ -69,7 +69,7 @@ namespace CSM.Injections
                         PanelManager.TogglePanel<HostGamePanel>();
 
                         // Display warning if DLCs or other mods are enabled
-                        if (DLCHelper.GetOwnedDLCs() != SteamHelper.DLC_BitMask.None)
+                        if (DLCHelper.GetOwnedExpansions() != SteamHelper.ExpansionBitMask.None || DLCHelper.GetOwnedModderPacks() != SteamHelper.ModderPackBitMask.None)
                         {
                             MessagePanel msgPanel = PanelManager.ShowPanel<MessagePanel>();
                             msgPanel.DisplayContentWarning();

--- a/src/csm/Networking/Client.cs
+++ b/src/csm/Networking/Client.cs
@@ -256,7 +256,8 @@ namespace CSM.Networking
                 ModVersion = versionString,
                 Password = Config.Password,
                 Username = Config.Username,
-                DLCBitMask = DLCHelper.GetOwnedDLCs(),
+                ExpansionBitMask = DLCHelper.GetOwnedExpansions(),
+                ModderPackBitMask = DLCHelper.GetOwnedModderPacks(),
                 Mods = ModSupport.Instance.RequiredModsForSync
             };
 

--- a/src/csm/Panels/MessagePanel.cs
+++ b/src/csm/Panels/MessagePanel.cs
@@ -177,21 +177,11 @@ namespace CSM.Panels
             Version version = Assembly.GetAssembly(typeof(CSM)).GetName().Version;
 
             string message = $"Version {version.Major}.{version.Minor}\n" +
-                             "Last Update: September 15th, 2022\n\n" +
+                             "Last Update: November 15th, 2022\n\n" +
                              "- Features:\n" +
-                             "  - Support Plazas Update\n" +
-                             "  - Sync soil trade\n" +
-                             "  - Sync street tree upgrades\n" +
-                             "  - Sync changed service vehicles\n" +
-                             "  - Add check if server is\n" +
-                             "    reachable from the internet\n" +
-                             "  - Add check for updates\n" +
-                             "  - Add modding API\n" +
-                             "  - Assets and supported mods need to be\n" +
-                             "    equal to the server's when joining\n" +
+                             "  - Support Roads and Vehicles Update\n\n" +
                              " - Fixes:\n" +
-                             "  - Support more screen resolutions\n" +
-                             "  - Support LoadingScreenMod\n";
+                             "  - Ignore order of mods for compatibility\n";
             SetMessage(message);
 
             Show(true);

--- a/src/csm/Panels/MessagePanel.cs
+++ b/src/csm/Panels/MessagePanel.cs
@@ -120,16 +120,16 @@ namespace CSM.Panels
             DLCPanelNew dlcPanel = FindObjectOfType<DLCPanelNew>();
 
             string message = "Your DLCs don't match with the server's DLCs\n\n";
-            if (compare.ClientMissing != SteamHelper.DLC_BitMask.None)
+            if (compare.ClientMissingExpansions != SteamHelper.ExpansionBitMask.None || compare.ClientMissingModderPack != SteamHelper.ModderPackBitMask.None)
             {
                 message += "You are missing the following DLCs:\n";
-                message += string.Join("\n", compare.ClientMissing.DLCs().Select(dlc => GetDlcName(dlcPanel, dlc)).ToArray());
+                message += string.Join("\n", SteamHelper.DLCs(compare.ClientMissingExpansions, compare.ClientMissingModderPack, SteamHelper.RadioBitMask.None).Select(dlc => GetDlcName(dlcPanel, dlc)).ToArray());
                 message += "\n\n";
             }
-            if (compare.ServerMissing != SteamHelper.DLC_BitMask.None)
+            if (compare.ServerMissingExpansions != SteamHelper.ExpansionBitMask.None || compare.ServerMissingModderPack != SteamHelper.ModderPackBitMask.None)
             {
                 message += "The server doesn't have the following DLCs:\n";
-                message += string.Join("\n", compare.ServerMissing.DLCs().Select(dlc => GetDlcName(dlcPanel, dlc)).ToArray());
+                message += string.Join("\n", SteamHelper.DLCs(compare.ServerMissingExpansions, compare.ServerMissingModderPack, SteamHelper.RadioBitMask.None).Select(dlc => GetDlcName(dlcPanel, dlc)).ToArray());
             }
 
             message += "\n\nDLCs can be enabled/disabled via checkbox in Steam.";


### PR DESCRIPTION
In this update they separated the DLC bit mask into the expansion, modder pack and radio station bit masks. Since we don't care about radio stations, we only need to check for equality of the expansions or modder packs.