### PR TITLE
Build script improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,8 @@ jobs:
     # The version string
     - name: Set Version Environment Variable
       id: csm_version
-      run: "version=$(date +'%y%m').${{ github.run_number }}" >> $env:GITHUB_OUTPUT
+      run: |
+          "version=$(date +'%y%m').${{ github.run_number }}" >> $env:GITHUB_OUTPUT
     
     # Update the assembly version to match the csm version
     - name: Update Assembly Version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,8 +89,8 @@ jobs:
       run: nuget push CitiesSkylinesMultiplayer.API.${{ steps.csm_version.outputs.version }}.0.nupkg ${{secrets.NUGET_API_KEY}} -NonInteractive -Source https://api.nuget.org/v3/index.json
 
   build-gs:
-    # Run this on windows
-    runs-on: windows-latest
+    # Run this on linux so it builds the correct docker image
+    runs-on: ubuntu-latest
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
@@ -105,7 +105,7 @@ jobs:
     - name: Login to docker registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       if: github.ref == 'refs/heads/master'
-      
+
     - name: Push Docker Image
       run: docker push ghcr.io/citiesskylinesmultiplayer/apiserver:latest
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     # The version string
     - name: Set Version Environment Variable
       id: csm_version
-      run: echo "version=$(date +'%y%m').${{ github.run_number }} >> $GITHUB_OUTPUT"
+      run: echo "version=$(date +'%y%m').${{ github.run_number }}" >> $GITHUB_OUTPUT
     
     # Update the assembly version to match the csm version
     - name: Update Assembly Version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,21 +23,21 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
         
     # The version string
     - name: Set Version Environment Variable
       id: csm_version
-      run: echo "::set-output name=version::$(date +'%y%m').${{ github.run_number }}"
+      run: echo "version=$(date +'%y%m').${{ github.run_number }} >> $GITHUB_OUTPUT"
     
-    # Update the assembly versiob to match the csm version
+    # Update the assembly version to match the csm version
     - name: Update Assembly Version
       run: powershell.exe -NoP -NonI -Command "../scripts/update-version.ps1 -filePattern AssemblyInfo.cs -assemblyVersion ${{ steps.csm_version.outputs.version }}.0.0 -assemblyFileVersion ${{ steps.csm_version.outputs.version }}.0.0"
       working-directory: src
     
     # Download the assemblies required to build the mod
     - name: Download Assemblies
-      uses: carlosperate/download-file-action@v1.0.3
+      uses: carlosperate/download-file-action@v2
       with:
         file-url: https://gridentertainment.blob.core.windows.net/general-storage/csm/Assemblies.zip
         # New filename to rename the downloaded file
@@ -64,14 +64,14 @@ jobs:
 
     # Publish artifacts
     - name: Upload mod DLLs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: CSM ${{ steps.csm_version.outputs.version }}
         path: src/csm/bin/Release/*.dll
         
     # Publish install script
     - name: Upload install script
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: CSM ${{ steps.csm_version.outputs.version }}
         path: scripts/install.ps1
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Build Docker Image
       working-directory: src/gs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     # The version string
     - name: Set Version Environment Variable
       id: csm_version
-      run: echo "version=$(date +'%y%m').${{ github.run_number }}" >> $GITHUB_OUTPUT
+      run: "version=$(date +'%y%m').${{ github.run_number }}" >> $env:GITHUB_OUTPUT
     
     # Update the assembly version to match the csm version
     - name: Update Assembly Version

--- a/src/gs/Dockerfile
+++ b/src/gs/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build-env
 WORKDIR /app
 
 COPY *.csproj ./

--- a/src/gs/Dockerfile
+++ b/src/gs/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build-env
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0 AS build-env
 WORKDIR /app
 
 COPY *.csproj ./


### PR DESCRIPTION
- Build GS on Linux instead of Windows (Linux images should work both on Linux and Windows, but the Windows image didn't work on Linux)
- Update build script versions
- Use environment files for the version number generation as "set-output" is deprecated
