### PR TITLE
Simplify API implementations by removing LiteNetLib dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,4 @@ __pycache__/
 .vscode/
 assemblies/*
 !assemblies/protobuf-net.dll
+!assemblies/LICENSE.txt

--- a/assemblies/LICENSE.txt
+++ b/assemblies/LICENSE.txt
@@ -1,0 +1,9 @@
+protobuf-net.dll was built from https://github.com/protobuf-net/protobuf-net on tag 2.4.8
+with the following the following config changes:
+FeatureServiceModel = false
+FeatureServiceModelConfiguration = false
+PlatformXmlSerializer = false
+PlatformBinaryFormatter = false
+
+protobuf-net is licensed under the Apache License, Version 2.0.
+See https://github.com/protobuf-net/protobuf-net/blob/main/Licence.txt

--- a/assemblies/LICENSE.txt
+++ b/assemblies/LICENSE.txt
@@ -1,5 +1,5 @@
 protobuf-net.dll was built from https://github.com/protobuf-net/protobuf-net on tag 2.4.8
-with the following the following config changes:
+with the following config changes:
 FeatureServiceModel = false
 FeatureServiceModelConfiguration = false
 PlatformXmlSerializer = false

--- a/examples/SampleExternalMod/SampleExternalMod.csproj
+++ b/examples/SampleExternalMod/SampleExternalMod.csproj
@@ -46,9 +46,11 @@
   <ItemGroup>
     <PackageReference Include="CitiesHarmony.API">
       <Version>2.0.0</Version>
+      <IncludeAssets>compile</IncludeAssets>
     </PackageReference>
     <PackageReference Include="protobuf-net">
       <Version>2.4.6</Version>
+      <IncludeAssets>compile</IncludeAssets>
     </PackageReference>
     <PackageReference Include="CitiesSkylinesMultiplayer.API">
       <Version>0.9.0</Version>
@@ -58,10 +60,12 @@
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\assemblies\Assembly-CSharp.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="ICities, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\assemblies\ICities.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/api/CSM.API.csproj
+++ b/src/api/CSM.API.csproj
@@ -54,9 +54,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\assemblies\protobuf-net.dll</HintPath>
     </Reference>
-    <PackageReference Include="LiteNetLib">
-      <Version>0.9.4</Version>
-    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/api/Networking/Player.cs
+++ b/src/api/Networking/Player.cs
@@ -1,5 +1,4 @@
 ﻿using CSM.API.Networking.Status;
-using LiteNetLib;
 
 namespace CSM.API.Networking
 {
@@ -7,24 +6,17 @@ namespace CSM.API.Networking
     {
         public string Username { get; set; }
 
-        public NetPeer NetPeer { get; set; }
-
         public long Latency { get; set; }
 
         public ClientStatus Status { get; set; }
 
-        public Player(NetPeer peer, string username)
+        public Player(string username)
         {
             Username = username;
-            NetPeer = peer;
             Latency = -1;
         }
 
-        public Player(string username) : this(null, username)
-        {
-        }
-
-        public Player() : this(null, null)
+        public Player()
         {
         }
     }

--- a/src/basegame/Injections/Tools/TransportToolHandler.cs
+++ b/src/basegame/Injections/Tools/TransportToolHandler.cs
@@ -76,11 +76,12 @@ namespace CSM.BaseGame.Injections.Tools
     {
         protected override void Configure(TransportTool tool, ToolController toolController, PlayerTransportToolCommand command) {
             // TODO: somehow force the rendering to occur even when clients aren't viewing the transport layer
-            tool.m_prefab = PrefabCollection<TransportInfo>.GetPrefab(command.TransportInfo);
+            // TODO: Implement this correctly, the following breaks our transport line synchronisation
+            /*tool.m_prefab = PrefabCollection<TransportInfo>.GetPrefab(command.TransportInfo);
             ReflectionHelper.SetAttr(tool, "m_lastEditLine", command.LastEditLine);
             ReflectionHelper.SetAttr(tool, "m_hoverStopIndex", command.HoverStopIndex);
             ReflectionHelper.SetAttr(tool, "m_hoverSegmentIndex", command.HoverSegmentIndex);
-            ReflectionHelper.SetAttr(tool, "m_hitPosition", command.HitPosition);
+            ReflectionHelper.SetAttr(tool, "m_hitPosition", command.HitPosition);*/
         }
 
         protected override CursorInfo GetCursorInfo(TransportTool tool)

--- a/src/csm/CSM.csproj
+++ b/src/csm/CSM.csproj
@@ -147,6 +147,7 @@
 		<Compile Include="Networking\Config\ClientConfig.cs" />
 		<Compile Include="Networking\Config\ConfigData.cs" />
 		<Compile Include="Networking\Config\ServerConfig.cs" />
+		<Compile Include="Networking\CSMPlayer.cs" />
 		<Compile Include="Networking\IpAddress.cs" />
 		<Compile Include="Networking\MultiplayerManager.cs" />
 		<Compile Include="Networking\Server.cs" />

--- a/src/csm/Commands/CommandInternal.cs
+++ b/src/csm/Commands/CommandInternal.cs
@@ -51,7 +51,14 @@ namespace CSM.Commands
         /// <param name="command">The command to send.</param>
         public void SendToClient(Player player, CommandBase command)
         {
-            SendToClient(player.NetPeer, command);
+            if (player is CSMPlayer csmPlayer)
+            {
+                SendToClient(csmPlayer.NetPeer, command);
+            }
+            else
+            {
+                Log.Warn("Trying to send packet to non-csm player, ignoring.");
+            }
         }
 
         /// <summary>
@@ -78,7 +85,7 @@ namespace CSM.Commands
         /// <param name="exclude">The player to not send the packet to.</param>
         public void SendToOtherClients(CommandBase command, Player exclude)
         {
-            foreach (Player player in MultiplayerManager.Instance.CurrentServer.ConnectedPlayers.Values)
+            foreach (CSMPlayer player in MultiplayerManager.Instance.CurrentServer.ConnectedPlayers.Values)
             {
                 if (player.Equals(exclude))
                     continue;

--- a/src/csm/Commands/Handler/Internal/ClientDisonnectHandler.cs
+++ b/src/csm/Commands/Handler/Internal/ClientDisonnectHandler.cs
@@ -36,10 +36,11 @@ namespace CSM.Commands.Handler.Internal
 
         public override void OnClientDisconnect(Player player)
         {
+            int clientId = player is CSMPlayer csmPlayer ? csmPlayer.NetPeer.Id : -2;
             Command.SendToClients(new ClientDisconnectCommand
             {
                 Username = player.Username,
-                ClientId = player.NetPeer.Id
+                ClientId = clientId
             });
         }
     }

--- a/src/csm/Commands/Handler/Internal/ConnectionRequestHandler.cs
+++ b/src/csm/Commands/Handler/Internal/ConnectionRequestHandler.cs
@@ -152,7 +152,7 @@ namespace CSM.Commands.Handler.Internal
             }
 
             // Add the new player as a connected player
-            Player newPlayer = new Player(peer, command.Username);
+            CSMPlayer newPlayer = new CSMPlayer(peer, command.Username);
             MultiplayerManager.Instance.CurrentServer.ConnectedPlayers[peer.Id] = newPlayer;
 
             // Send the result command

--- a/src/csm/Networking/CSMPlayer.cs
+++ b/src/csm/Networking/CSMPlayer.cs
@@ -1,0 +1,20 @@
+using CSM.API.Networking;
+using LiteNetLib;
+
+namespace CSM.Networking
+{
+    public class CSMPlayer : Player
+    {
+        public NetPeer NetPeer { get; }
+
+        public CSMPlayer(NetPeer peer, string username) : base(username)
+        {
+            NetPeer = peer;
+        }
+
+        public CSMPlayer(string username) : base(username)
+        {
+            NetPeer = null;
+        }
+    }
+}

--- a/src/csm/Networking/Server.cs
+++ b/src/csm/Networking/Server.cs
@@ -35,14 +35,14 @@ namespace CSM.Networking
         private int _keepAlive = 1;
         
         // Connected clients
-        public Dictionary<int, Player> ConnectedPlayers { get; } = new Dictionary<int, Player>();
+        public Dictionary<int, CSMPlayer> ConnectedPlayers { get; } = new Dictionary<int, CSMPlayer>();
 
         /// <summary>
         ///     Get the Player object of the server host
         /// </summary>
-        public Player HostPlayer { get { return _hostPlayer; } }
+        public CSMPlayer HostPlayer { get { return _hostPlayer; } }
         // The player instance for the host player
-        private Player _hostPlayer;
+        private CSMPlayer _hostPlayer;
 
         // Config options for server
         public ServerConfig Config { get; private set; }
@@ -137,7 +137,7 @@ namespace CSM.Networking
             Status = ServerStatus.Running;
 
             // Initialize host player
-            _hostPlayer = new Player(Config.Username);
+            _hostPlayer = new CSMPlayer(Config.Username);
             _hostPlayer.Status = ClientStatus.Connected;
             MultiplayerManager.Instance.PlayerList.Add(_hostPlayer.Username);
 
@@ -333,7 +333,7 @@ namespace CSM.Networking
 
         private void ListenerOnNetworkLatencyUpdateEvent(NetPeer peer, int latency)
         {
-            if (!ConnectedPlayers.TryGetValue(peer.Id, out Player player))
+            if (!ConnectedPlayers.TryGetValue(peer.Id, out CSMPlayer player))
                 return;
 
             player.Latency = latency;
@@ -341,7 +341,7 @@ namespace CSM.Networking
 
         private void ListenerOnPeerDisconnectedEvent(NetPeer peer, DisconnectInfo disconnectInfo)
         {
-            if (!ConnectedPlayers.TryGetValue(peer.Id, out Player player))
+            if (!ConnectedPlayers.TryGetValue(peer.Id, out CSMPlayer player))
                 return;
 
             Log.Info($"Player {player.Username} lost connection! Reason: {disconnectInfo.Reason}");
@@ -381,7 +381,7 @@ namespace CSM.Networking
             }
         }
 
-        public void HandlePlayerDisconnect(Player player)
+        public void HandlePlayerDisconnect(CSMPlayer player)
         {
             MultiplayerManager.Instance.PlayerList.Remove(player.Username);
             this.ConnectedPlayers.Remove(player.NetPeer.Id);
@@ -408,7 +408,7 @@ namespace CSM.Networking
         /// <summary>
         ///     Get the Player object by username. Warning, expensive call!!!
         /// </summary>
-        public Player GetPlayerByUsername(string username)
+        public CSMPlayer GetPlayerByUsername(string username)
         {
             if (username == HostPlayer.Username)
                 return HostPlayer;

--- a/src/csm/Panels/MessagePanel.cs
+++ b/src/csm/Panels/MessagePanel.cs
@@ -189,11 +189,22 @@ namespace CSM.Panels
             Version version = Assembly.GetAssembly(typeof(CSM)).GetName().Version;
 
             string message = $"Version {version.Major}.{version.Minor}\n" +
-                             "Last Update: November 15th, 2022\n\n" +
+                             "Last Update: April 12th, 2023\n\n" +
                              "- Features:\n" +
-                             "  - Support Roads and Vehicles Update\n\n" +
-                             " - Fixes:\n" +
-                             "  - Ignore order of mods for compatibility\n";
+                             "  - Better NAT traversal, now using our API server\n" +
+                             "    to negotiate connections\n" +
+                             "  -> This means you should no longer need\n" +
+                             "     Hamachi or similar VPN solutions!\n" +
+                             "     (Tell us on Discord about your experience)\n\n" +
+                             "  - You can now join using the Steam friends menu\n" +
+                             "  - New player cursors show the mouse position\n" +
+                             "    and current tool of other players\n" +
+                             "  - Save game download progress is now shown\n" +
+                             "  - Similar chat messages are now merged\n\n" +
+                             "- Fixes:\n" +
+                             "  - Handle timeouts while joining correctly\n" +
+                             "  - Fix several exceptions from the log\n" +
+                             "  - Fix some game crashes";
             SetMessage(message);
 
             Show(true);

--- a/src/csm/Panels/MessagePanel.cs
+++ b/src/csm/Panels/MessagePanel.cs
@@ -189,7 +189,7 @@ namespace CSM.Panels
             Version version = Assembly.GetAssembly(typeof(CSM)).GetName().Version;
 
             string message = $"Version {version.Major}.{version.Minor}\n" +
-                             "Last Update: April 12th, 2023\n\n" +
+                             "Last Update: April 14th, 2023\n\n" +
                              "- Features:\n" +
                              "  - Better NAT traversal, now using our API server\n" +
                              "    to negotiate connections\n" +


### PR DESCRIPTION
Removed the LiteNetLib from CSM.API so implementing mods don't throw errors if CSM is not available.
This is realized by removing the NetPeer field from the Player class.
- Also explain how the bundled protobuf-net.dll is created
- Update changelog panel
- Fix transport line synchronization, which was broken by the new transport tool sync. Removed this for now (wasn't working correctly anyway)
