### PR TITLE
Fix problems of new hotels update

### DIFF
--- a/src/csm/Networking/Server.cs
+++ b/src/csm/Networking/Server.cs
@@ -402,7 +402,8 @@ namespace CSM.Networking
         /// </summary>
         private void ListenerOnNetworkErrorEvent(IPEndPoint endpoint, SocketError socketError)
         {
-            Log.Error($"Received an error from {endpoint.Address}:{endpoint.Port}. Code: {socketError}");
+            string source = endpoint != null ? $"{endpoint.Address}:{endpoint.Port}" : "<Unconnected>";
+            Log.Error($"Received an error from {source}. Code: {socketError}");
         }
 
         /// <summary>

--- a/src/csm/Panels/MessagePanel.cs
+++ b/src/csm/Panels/MessagePanel.cs
@@ -113,9 +113,9 @@ namespace CSM.Panels
             Show(true);
         }
 
-        private string GetDlcName(DLCPanelNew panel, SteamHelper.DLC dlc)
+        private string GetDlcName(DLCList list, SteamHelper.DLC dlc)
         {
-            string dlcName = panel.FindLocalizedDLCName(dlc);
+            string dlcName = list.FindLocalizedDLCName(dlc);
             if (string.IsNullOrEmpty(dlcName))
             {
                 // Default to enum item name
@@ -129,7 +129,7 @@ namespace CSM.Panels
         {
             SetTitle("DLC Mismatch");
 
-            DLCPanelNew dlcPanel = FindObjectOfType<DLCPanelNew>();
+            DLCList dlcPanel = FindObjectOfType<DLCList>();
 
             string message = "Your DLCs don't match with the server's DLCs\n\n";
             if (compare.ClientMissingExpansions != SteamHelper.ExpansionBitMask.None || compare.ClientMissingModderPack != SteamHelper.ModderPackBitMask.None)


### PR DESCRIPTION
Also fix unrelated exception reported by a few members on Discord.

CSM should work again with the new update, although no new features are synced yet.

Assemblies need updating before building the release version.