### PR TITLE
Implement sync of zoning grid flags

### DIFF
--- a/src/basegame/Commands/Data/Net/NodeCreateCommand.cs
+++ b/src/basegame/Commands/Data/Net/NodeCreateCommand.cs
@@ -82,5 +82,11 @@ namespace CSM.BaseGame.Commands.Data.Net
         /// </summary>
         [ProtoMember(12)]
         public ushort RelocateBuildingId { get; set; }
+
+        /// <summary>
+        ///     The zone grid flags (left/right/both zoning).
+        /// </summary>
+        [ProtoMember(13)]
+        public NetSegment.Flags2 ZoneGridFlags { get; set; }
     }
 }

--- a/src/basegame/Commands/Handler/Net/NodeCreateHandler.cs
+++ b/src/basegame/Commands/Handler/Net/NodeCreateHandler.cs
@@ -17,10 +17,15 @@ namespace CSM.BaseGame.Commands.Handler.Net
 
             FastList<NetTool.NodePosition> nodeBuffer = new FastList<NetTool.NodePosition>();
 
+            NetSegment.Flags2 oldZoneGridFlags = NetTool.m_zoneGridFlags;
+            NetTool.m_zoneGridFlags = command.ZoneGridFlags;
+
             NetTool.CreateNode(prefab, command.StartPoint, command.MiddlePoint, command.EndPoint, nodeBuffer,
                 command.MaxSegments, false, command.TestEnds, false, command.AutoFix, false,
                 command.Invert, command.SwitchDir, command.RelocateBuildingId, out ushort _,
                 out ushort _, out ushort _, out int _, out int _);
+
+            NetTool.m_zoneGridFlags = oldZoneGridFlags;
 
             ArrayHandler.StopApplying();
             IgnoreHelper.Instance.EndIgnore();

--- a/src/basegame/Injections/NetHandler.cs
+++ b/src/basegame/Injections/NetHandler.cs
@@ -59,7 +59,8 @@ namespace CSM.BaseGame.Injections
                 AutoFix = autoFix,
                 Invert = invert,
                 SwitchDir = switchDir,
-                RelocateBuildingId = relocateBuildingID
+                RelocateBuildingId = relocateBuildingID,
+                ZoneGridFlags = NetTool.m_zoneGridFlags
             });
         }
 


### PR DESCRIPTION
Update 1.17 of C:S added the possibility to configure which sides of the roads contain zoning space. This PR finally syncs those settings.
Fixes #318 