### PR TITLE
Support Match Day and Campus DLCs

### DIFF
--- a/src/api/CSM.API.csproj
+++ b/src/api/CSM.API.csproj
@@ -34,7 +34,6 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Threading" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Chat.cs" />
@@ -49,6 +48,11 @@
     <Compile Include="Networking\Status\ClientStatus.cs" />
     <Compile Include="Networking\Status\ServerStatus.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Threading.dll">
+      <Version>1.0.2856.0</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="protobuf-net">

--- a/src/api/CSM.API.csproj
+++ b/src/api/CSM.API.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Threading" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Chat.cs" />

--- a/src/api/Helpers/ReflectionHelper.cs
+++ b/src/api/Helpers/ReflectionHelper.cs
@@ -102,6 +102,16 @@ namespace CSM.API.Helpers
             return obj.GetType().GetField(attribute, AllAccessFlags)?.GetValue(obj);
         }
 
+        public static T GetAttr<T>(Type type, string attribute)
+        {
+            return (T) GetAttr(type, attribute);
+        }
+
+        public static object GetAttr(Type type, string attribute)
+        {
+            return type.GetField(attribute, AllAccessFlags)?.GetValue(null);
+        }
+
         public static T GetProp<T>(object obj, string property)
         {
             return (T) GetProp(obj, property);

--- a/src/basegame/CSM.BaseGame.csproj
+++ b/src/basegame/CSM.BaseGame.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Commands\Data\Buildings\BuildingUpgradeCommand.cs" />
     <Compile Include="Commands\Data\Buildings\ServiceBuildingChangeVehicleCommand.cs" />
     <Compile Include="Commands\Data\Campus\BuyResearchGrantCommand.cs" />
+    <Compile Include="Commands\Data\Campus\OnAcademicYearEndCommand.cs" />
     <Compile Include="Commands\Data\Campus\SetAcademicStaffCountCommand.cs" />
     <Compile Include="Commands\Data\Campus\SetCheerleadingBudgetCommand.cs" />
     <Compile Include="Commands\Data\Campus\SetCoachesCountCommand.cs" />
@@ -159,6 +160,7 @@
     <Compile Include="Commands\Handler\Buildings\BuildingUpgradeHandler.cs" />
     <Compile Include="Commands\Handler\Buildings\TransportLineChangeVehicleHandler.cs" />
     <Compile Include="Commands\Handler\Campus\BuyResearchGrantHandler.cs" />
+    <Compile Include="Commands\Handler\Campus\OnAcademicYearEndHandler.cs" />
     <Compile Include="Commands\Handler\Campus\SetAcademicStaffCountHandler.cs" />
     <Compile Include="Commands\Handler\Campus\SetCheerleadingBudgetHandler.cs" />
     <Compile Include="Commands\Handler\Campus\SetCoachesCountHandler.cs" />

--- a/src/basegame/CSM.BaseGame.csproj
+++ b/src/basegame/CSM.BaseGame.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Commands\Data\Economy\EconomyTakeLoanCommand.cs" />
     <Compile Include="Commands\Data\Events\EventActivateCommand.cs" />
     <Compile Include="Commands\Data\Events\EventColorChangedCommand.cs" />
+    <Compile Include="Commands\Data\Events\EventSetResultCommand.cs" />
     <Compile Include="Commands\Data\Events\EventSetSecurityBudgetCommand.cs" />
     <Compile Include="Commands\Data\Events\EventSetTicketPriceCommand.cs" />
     <Compile Include="Commands\Data\Names\ChangeCityNameCommand.cs" />
@@ -165,6 +166,7 @@
     <Compile Include="Commands\Handler\Economy\EconomyTakeLoanHandler.cs" />
     <Compile Include="Commands\Handler\Events\EventActivateHandler.cs" />
     <Compile Include="Commands\Handler\Events\EventColorChangedHandler.cs" />
+    <Compile Include="Commands\Handler\Events\EventSetResultHandler.cs" />
     <Compile Include="Commands\Handler\Events\EventSetSecurityBudgetHandler.cs" />
     <Compile Include="Commands\Handler\Events\EventSetTicketPriceHandler.cs" />
     <Compile Include="Commands\Handler\Names\ChangeCityNameHandler.cs" />

--- a/src/basegame/CSM.BaseGame.csproj
+++ b/src/basegame/CSM.BaseGame.csproj
@@ -79,7 +79,15 @@
     <Compile Include="Commands\Data\Buildings\BuildingToolCreateCommand.cs" />
     <Compile Include="Commands\Data\Buildings\BuildingUpgradeCommand.cs" />
     <Compile Include="Commands\Data\Buildings\ServiceBuildingChangeVehicleCommand.cs" />
+    <Compile Include="Commands\Data\Campus\BuyResearchGrantCommand.cs" />
+    <Compile Include="Commands\Data\Campus\SetAcademicStaffCountCommand.cs" />
+    <Compile Include="Commands\Data\Campus\SetCheerleadingBudgetCommand.cs" />
+    <Compile Include="Commands\Data\Campus\SetCoachesCountCommand.cs" />
+    <Compile Include="Commands\Data\Campus\SetTicketPriceCommand.cs" />
+    <Compile Include="Commands\Data\Campus\SetVarsityColorCommand.cs" />
+    <Compile Include="Commands\Data\Campus\SetVarsityIdentityCommand.cs" />
     <Compile Include="Commands\Data\Districts\DistrictAreaModifyCommand.cs" />
+    <Compile Include="Commands\Data\Districts\DistrictChangeStyleCommand.cs" />
     <Compile Include="Commands\Data\Districts\DistrictCityPolicyCommand.cs" />
     <Compile Include="Commands\Data\Districts\DistrictCityPolicyUnsetCommand.cs" />
     <Compile Include="Commands\Data\Districts\DistrictCreateCommand.cs" />
@@ -150,7 +158,15 @@
     <Compile Include="Commands\Handler\Buildings\BuildingToolCreateHandler.cs" />
     <Compile Include="Commands\Handler\Buildings\BuildingUpgradeHandler.cs" />
     <Compile Include="Commands\Handler\Buildings\TransportLineChangeVehicleHandler.cs" />
+    <Compile Include="Commands\Handler\Campus\BuyResearchGrantHandler.cs" />
+    <Compile Include="Commands\Handler\Campus\SetAcademicStaffCountHandler.cs" />
+    <Compile Include="Commands\Handler\Campus\SetCheerleadingBudgetHandler.cs" />
+    <Compile Include="Commands\Handler\Campus\SetCoachesCountHandler.cs" />
+    <Compile Include="Commands\Handler\Campus\SetTicketPriceHandler.cs" />
+    <Compile Include="Commands\Handler\Campus\SetVarsityColorHandler.cs" />
+    <Compile Include="Commands\Handler\Campus\SetVarsityIdentityHandler.cs" />
     <Compile Include="Commands\Handler\Districts\DistrictAreaModifyHandler.cs" />
+    <Compile Include="Commands\Handler\Districts\DistrictChangeStyleHandler.cs" />
     <Compile Include="Commands\Handler\Districts\DistrictCityPolicyHandler.cs" />
     <Compile Include="Commands\Handler\Districts\DistrictCityPolicyUnsetHandler.cs" />
     <Compile Include="Commands\Handler\Districts\DistrictCreateHandler.cs" />
@@ -215,6 +231,7 @@
     <Compile Include="Helpers\ToolSimulator.cs" />
     <Compile Include="Injections\ArrayHandler.cs" />
     <Compile Include="Injections\BuildingHandler.cs" />
+    <Compile Include="Injections\CampusHandler.cs" />
     <Compile Include="Injections\DistrictHandler.cs" />
     <Compile Include="Injections\EconomyHandler.cs" />
     <Compile Include="Injections\EventHandler.cs" />
@@ -257,10 +274,6 @@
       <Project>{ab27eacd-b9a9-42bc-bf8a-3b25aabff6ca}</Project>
       <Name>CSM.API</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Commands\Data" />
-    <Folder Include="Commands\Handler" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/basegame/Commands/Data/Campus/BuyResearchGrantCommand.cs
+++ b/src/basegame/Commands/Data/Campus/BuyResearchGrantCommand.cs
@@ -1,0 +1,26 @@
+using CSM.API.Commands;
+using ProtoBuf;
+
+namespace CSM.BaseGame.Commands.Data.Campus
+{
+    /// <summary>
+    ///     Called when a new research grant is bought for a campus.
+    /// </summary>
+    /// Sent by:
+    /// - CampusHandler
+    [ProtoContract]
+    public class BuyResearchGrantCommand : CommandBase
+    {
+        /// <summary>
+        ///     The park id of the campus.
+        /// </summary>
+        [ProtoMember(1)]
+        public byte Campus { get; set; }
+
+        /// <summary>
+        ///     The type of the research grant.
+        /// </summary>
+        [ProtoMember(2)]
+        public byte GrantType { get; set; }
+    }
+}

--- a/src/basegame/Commands/Data/Campus/OnAcademicYearEndCommand.cs
+++ b/src/basegame/Commands/Data/Campus/OnAcademicYearEndCommand.cs
@@ -1,0 +1,27 @@
+using CSM.API.Commands;
+using ProtoBuf;
+
+namespace CSM.BaseGame.Commands.Data.Campus
+{
+    [ProtoContract]
+    public class OnAcademicYearEndCommand : CommandBase
+    {
+        [ProtoMember(1)]
+        public byte ParkId { get; set; }
+
+        [ProtoMember(2)]
+        public AcademicWorksData AcademicWorksData { get; set; }
+
+        [ProtoMember(3)]
+        public DistrictYearReportData[] LedgerReports { get; set; }
+
+        [ProtoMember(4)]
+        public int DynamicAttractiveness { get; set; }
+
+        [ProtoMember(5)]
+        public DistrictPark.ParkLevel OldParkLevel { get; set; }
+
+        [ProtoMember(6)]
+        public DistrictPark.ParkLevel NewParkLevel { get; set; }
+    }
+}

--- a/src/basegame/Commands/Data/Campus/OnAcademicYearEndCommand.cs
+++ b/src/basegame/Commands/Data/Campus/OnAcademicYearEndCommand.cs
@@ -3,24 +3,47 @@ using ProtoBuf;
 
 namespace CSM.BaseGame.Commands.Data.Campus
 {
+    /// <summary>
+    ///     Called when the academic year of a campus area ends.
+    /// </summary>
+    /// Sent by:
+    /// - CampusHandler
     [ProtoContract]
     public class OnAcademicYearEndCommand : CommandBase
     {
+        /// <summary>
+        ///     The park id of the campus area.
+        /// </summary>
         [ProtoMember(1)]
         public byte ParkId { get; set; }
 
+        /// <summary>
+        ///     Information regarding the academic works.
+        /// </summary>
         [ProtoMember(2)]
         public AcademicWorksData AcademicWorksData { get; set; }
 
+        /// <summary>
+        ///     Statistical data of the campus area used in the academic year info panel.
+        /// </summary>
         [ProtoMember(3)]
         public DistrictYearReportData[] LedgerReports { get; set; }
 
+        /// <summary>
+        ///     The new dynamic attractiveness modifier.
+        /// </summary>
         [ProtoMember(4)]
         public int DynamicAttractiveness { get; set; }
 
+        /// <summary>
+        ///     The park level of the previous year.
+        /// </summary>
         [ProtoMember(5)]
         public DistrictPark.ParkLevel OldParkLevel { get; set; }
 
+        /// <summary>
+        ///     The park level in the following year.
+        /// </summary>
         [ProtoMember(6)]
         public DistrictPark.ParkLevel NewParkLevel { get; set; }
     }

--- a/src/basegame/Commands/Data/Campus/SetAcademicStaffCountCommand.cs
+++ b/src/basegame/Commands/Data/Campus/SetAcademicStaffCountCommand.cs
@@ -1,0 +1,26 @@
+using CSM.API.Commands;
+using ProtoBuf;
+
+namespace CSM.BaseGame.Commands.Data.Campus
+{
+    /// <summary>
+    ///     Called when the count of academic staff is set for a campus.
+    /// </summary>
+    /// Sent by:
+    /// - CampusHandler
+    [ProtoContract]
+    public class SetAcademicStaffCountCommand : CommandBase
+    {
+        /// <summary>
+        ///     The park id of the campus.
+        /// </summary>
+        [ProtoMember(1)]
+        public byte Campus { get; set; }
+
+        /// <summary>
+        ///     The new amount of staff.
+        /// </summary>
+        [ProtoMember(2)]
+        public byte Count { get; set; }
+    }
+}

--- a/src/basegame/Commands/Data/Campus/SetCheerleadingBudgetCommand.cs
+++ b/src/basegame/Commands/Data/Campus/SetCheerleadingBudgetCommand.cs
@@ -1,0 +1,26 @@
+using CSM.API.Commands;
+using ProtoBuf;
+
+namespace CSM.BaseGame.Commands.Data.Campus
+{
+    /// <summary>
+    ///     Called when the cheerleading budget of a campus is changed.
+    /// </summary>
+    /// Sent by:
+    /// - CampusHandler
+    [ProtoContract]
+    public class SetCheerleadingBudgetCommand : CommandBase
+    {
+        /// <summary>
+        ///     The park id of the campus.
+        /// </summary>
+        [ProtoMember(1)]
+        public byte Campus { get; set; }
+
+        /// <summary>
+        ///     The new cheerleading budget.
+        /// </summary>
+        [ProtoMember(2)]
+        public int Budget { get; set; }
+    }
+}

--- a/src/basegame/Commands/Data/Campus/SetCoachesCountCommand.cs
+++ b/src/basegame/Commands/Data/Campus/SetCoachesCountCommand.cs
@@ -1,0 +1,33 @@
+using System;
+using CSM.API.Commands;
+using ProtoBuf;
+
+namespace CSM.BaseGame.Commands.Data.Campus
+{
+    /// <summary>
+    ///     Called when the count of varsity coaches is set for a campus.
+    /// </summary>
+    /// Sent by:
+    /// - CampusHandler
+    [ProtoContract]
+    public class SetCoachesCountCommand : CommandBase
+    {
+        /// <summary>
+        ///     The park id of the campus.
+        /// </summary>
+        [ProtoMember(1)]
+        public byte Campus { get; set; }
+
+        /// <summary>
+        ///     The new amount of staff.
+        /// </summary>
+        [ProtoMember(2)]
+        public byte Count { get; set; }
+
+        /// <summary>
+        ///     The timestamps when the new coaches were hired.
+        /// </summary>
+        [ProtoMember(3)]
+        public DateTime[] CoachHireTimes { get; set; }
+    }
+}

--- a/src/basegame/Commands/Data/Campus/SetTicketPriceCommand.cs
+++ b/src/basegame/Commands/Data/Campus/SetTicketPriceCommand.cs
@@ -1,0 +1,26 @@
+using CSM.API.Commands;
+using ProtoBuf;
+
+namespace CSM.BaseGame.Commands.Data.Campus
+{
+    /// <summary>
+    ///     Called when the ticket price for varsity sports is set on a campus.
+    /// </summary>
+    /// Sent by:
+    /// - CampusHandler
+    [ProtoContract]
+    public class SetTicketPriceCommand : CommandBase
+    {
+        /// <summary>
+        ///     The park id of the campus.
+        /// </summary>
+        [ProtoMember(1)]
+        public byte Campus { get; set; }
+
+        /// <summary>
+        ///     The new ticket price.
+        /// </summary>
+        [ProtoMember(2)]
+        public ushort Price { get; set; }
+    }
+}

--- a/src/basegame/Commands/Data/Campus/SetVarsityColorCommand.cs
+++ b/src/basegame/Commands/Data/Campus/SetVarsityColorCommand.cs
@@ -1,0 +1,27 @@
+using CSM.API.Commands;
+using ProtoBuf;
+using UnityEngine;
+
+namespace CSM.BaseGame.Commands.Data.Campus
+{
+    /// <summary>
+    ///     Called when the color of the varsity sports is set for a campus.
+    /// </summary>
+    /// Sent by:
+    /// - CampusHandler
+    [ProtoContract]
+    public class SetVarsityColorCommand : CommandBase
+    {
+        /// <summary>
+        ///     The park id of the campus.
+        /// </summary>
+        [ProtoMember(1)]
+        public byte Campus { get; set; }
+
+        /// <summary>
+        ///     The new varsity color.
+        /// </summary>
+        [ProtoMember(2)]
+        public Color Color { get; set; }
+    }
+}

--- a/src/basegame/Commands/Data/Campus/SetVarsityIdentityCommand.cs
+++ b/src/basegame/Commands/Data/Campus/SetVarsityIdentityCommand.cs
@@ -1,0 +1,26 @@
+using CSM.API.Commands;
+using ProtoBuf;
+
+namespace CSM.BaseGame.Commands.Data.Campus
+{
+    /// <summary>
+    ///     Called when the identity of the varsity sports is set for a campus.
+    /// </summary>
+    /// Sent by:
+    /// - CampusHandler
+    [ProtoContract]
+    public class SetVarsityIdentityCommand : CommandBase
+    {
+        /// <summary>
+        ///     The park id of the campus.
+        /// </summary>
+        [ProtoMember(1)]
+        public byte Campus { get; set; }
+
+        /// <summary>
+        ///     The new varsity identity.
+        /// </summary>
+        [ProtoMember(2)]
+        public int Identity { get; set; }
+    }
+}

--- a/src/basegame/Commands/Data/Districts/DistrictChangeStyleCommand.cs
+++ b/src/basegame/Commands/Data/Districts/DistrictChangeStyleCommand.cs
@@ -4,27 +4,21 @@ using ProtoBuf;
 namespace CSM.BaseGame.Commands.Data.Districts
 {
     /// <summary>
-    ///     Called when a district policy is set.
+    ///     Called when the building style of a district is changed.
     /// </summary>
     [ProtoContract]
-    public class DistrictPolicyCommand : CommandBase
+    public class DistrictChangeStyleCommand : CommandBase
     {
         /// <summary>
-        ///     The district policy to set.
+        ///     The district style to set.
         /// </summary>
         [ProtoMember(1)]
-        public DistrictPolicies.Policies Policy { get; set; }
+        public ushort Style { get; set; }
 
         /// <summary>
         ///     The modified district.
         /// </summary>
         [ProtoMember(2)]
         public byte DistrictId { get; set; }
-
-        /// <summary>
-        ///     If the target is a park instead of a district.
-        /// </summary>
-        [ProtoMember(3)]
-        public bool IsPark { get; set; }
     }
 }

--- a/src/basegame/Commands/Data/Districts/DistrictPolicyUnsetCommand.cs
+++ b/src/basegame/Commands/Data/Districts/DistrictPolicyUnsetCommand.cs
@@ -22,5 +22,11 @@ namespace CSM.BaseGame.Commands.Data.Districts
         /// </summary>
         [ProtoMember(2)]
         public byte DistrictId { get; set; }
+
+        /// <summary>
+        ///     If the target is a park instead of a district.
+        /// </summary>
+        [ProtoMember(3)]
+        public bool IsPark { get; set; }
     }
 }

--- a/src/basegame/Commands/Data/Events/EventSetResultCommand.cs
+++ b/src/basegame/Commands/Data/Events/EventSetResultCommand.cs
@@ -1,0 +1,26 @@
+using CSM.API.Commands;
+using ProtoBuf;
+
+namespace CSM.BaseGame.Commands.Data.Events
+{
+    /// <summary>
+    ///     Called when the the result of an event (sports match) is set.
+    /// </summary>
+    /// Sent by:
+    /// - EventHandler
+    [ProtoContract]
+    public class EventSetResultCommand : CommandBase
+    {
+        /// <summary>
+        ///     The id of the event that was modified.
+        /// </summary>
+        [ProtoMember(1)]
+        public ushort Event { get; set; }
+
+        /// <summary>
+        ///     The event result
+        /// </summary>
+        [ProtoMember(2)]
+        public bool Result { get; set; }
+    }
+}

--- a/src/basegame/Commands/Handler/Campus/BuyResearchGrantHandler.cs
+++ b/src/basegame/Commands/Handler/Campus/BuyResearchGrantHandler.cs
@@ -1,0 +1,25 @@
+using ColossalFramework;
+using CSM.API.Commands;
+using CSM.API.Helpers;
+using CSM.BaseGame.Commands.Data.Campus;
+using CSM.BaseGame.Helpers;
+
+namespace CSM.BaseGame.Commands.Handler.Campus
+{
+    public class BuyResearchGrantHandler : CommandHandler<BuyResearchGrantCommand>
+    {
+        protected override void Handle(BuyResearchGrantCommand command)
+        {
+            Singleton<DistrictManager>.instance.m_parks.m_buffer[command.Campus].m_grantType = command.GrantType;
+
+            // Refresh panel
+            if (InfoPanelHelper.IsPark(typeof(CampusWorldInfoPanel), command.Campus, out WorldInfoPanel panel))
+            {
+                SimulationManager.instance.m_ThreadingWrapper.QueueMainThread(() =>
+                {
+                    ReflectionHelper.Call((CampusWorldInfoPanel)panel, "OnSetTarget");
+                });
+            }
+        }
+    }
+}

--- a/src/basegame/Commands/Handler/Campus/OnAcademicYearEndHandler.cs
+++ b/src/basegame/Commands/Handler/Campus/OnAcademicYearEndHandler.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using ColossalFramework;
+using ColossalFramework.Threading;
+using ColossalFramework.UI;
+using CSM.API.Commands;
+using CSM.API.Helpers;
+using CSM.BaseGame.Commands.Data.Campus;
+using UnityEngine;
+
+namespace CSM.BaseGame.Commands.Handler.Campus
+{
+    public class OnAcademicYearEndHandler : CommandHandler<OnAcademicYearEndCommand>
+    {
+        protected override void Handle(OnAcademicYearEndCommand command)
+        {
+            // This is a reproduction of the effects of DistrictPark::OnAcademicYearEnded
+            ref DistrictPark park = ref Singleton<DistrictManager>.instance.m_parks.m_buffer[command.ParkId];
+            park.m_flags &= ~DistrictPark.Flags.Graduation;
+            park.m_awayMatchesDone = null;
+            park.m_academicWorksData = command.AcademicWorksData;
+            ReflectionHelper.SetAttr(park.m_ledger, "m_reports", command.LedgerReports);
+            park.m_grantType = 0;
+            park.m_dynamicVarsityAttractivenessModifier = command.DynamicAttractiveness;
+            park.m_academicStaffAccumulation = 0.0f;
+            if (park.m_sports != DistrictPark.Sports.None)
+            {
+                park.m_lifetimeTrophies += park.m_ledger.ReadTrophyCount(DistrictPark.AcademicYear.Last);
+            }
+            Singleton<MessageManager>.instance.TryCreateMessage("GRADUATIONCHIRP_GENERIC", null, Singleton<MessageManager>.instance.GetRandomResidentID());
+
+            // Now the content of DistrictPark::RefreshCampusLevel
+            if (command.NewParkLevel > command.OldParkLevel)
+            {
+                for (DistrictPark.ParkLevel newLevel = command.OldParkLevel + 1; newLevel <= command.NewParkLevel; ++newLevel)
+                    Singleton<DistrictManager>.instance.SetParkTypeLevel(command.ParkId, park.m_parkType, newLevel);
+            }
+            else
+            {
+                if (command.OldParkLevel >= DistrictPark.ParkLevel.Level4 && command.NewParkLevel <= DistrictPark.ParkLevel.Level3 &&
+                    Singleton<DistrictManager>.instance.IsParkPolicySet(DistrictPolicies.Policies.SponsorshipDeal, command.ParkId))
+                    Singleton<DistrictManager>.instance.UnsetParkPolicy(DistrictPolicies.Policies.SponsorshipDeal, command.ParkId);
+                Singleton<DistrictManager>.instance.SetParkTypeLevel(command.ParkId, park.m_parkType, command.NewParkLevel);
+            }
+            Singleton<DistrictManager>.instance.ParkNamesModified();
+            if (command.NewParkLevel == DistrictPark.ParkLevel.Level5 && Singleton<SimulationManager>.instance.m_metaData.m_disableAchievements != SimulationMetaData.MetaBool.True)
+                ThreadHelper.dispatcher.Dispatch(() => SteamHelper.UnlockAchievement("DistinguishedAcademics"));
+            if (command.NewParkLevel != command.OldParkLevel)
+            {
+                FastList<ushort> serviceBuildings = Singleton<BuildingManager>.instance.GetServiceBuildings(ItemClass.Service.PlayerEducation);
+                for (int index1 = 0; index1 < serviceBuildings.m_size; ++index1)
+                {
+                    ushort index2 = serviceBuildings.m_buffer[index1];
+                    if (Singleton<DistrictManager>.instance.GetPark(Singleton<BuildingManager>.instance.m_buildings.m_buffer[index2].m_position) == command.ParkId)
+                    {
+                        BuildingInfo info = Singleton<BuildingManager>.instance.m_buildings.m_buffer[index2].Info;
+                        if (info != null && (info.m_buildingAI is MainCampusBuildingAI || info.m_buildingAI is CampusBuildingAI))
+                        {
+                            Vector3 position = Singleton<BuildingManager>.instance.m_buildings.m_buffer[index2].m_position;
+                            position.y += info.m_size.y;
+                            Singleton<NotificationManager>.instance.AddEvent(command.NewParkLevel >= command.OldParkLevel ? NotificationEvent.Type.PlayerLevelUp : NotificationEvent.Type.LoseHappiness, position, 1f);
+                        }
+                    }
+                }
+            }
+
+            if (Singleton<DistrictManager>.instance.m_properties != null)
+            {
+                EffectInfo campusLevelupEffect = Singleton<DistrictManager>.instance.m_properties.m_campusLevelupEffect;
+
+                if (campusLevelupEffect != null)
+                {
+                    InstanceID instance3 = new InstanceID();
+                    instance3.Park = command.ParkId;
+                    EffectInfo.SpawnArea spawnArea = new EffectInfo.SpawnArea(park.m_nameLocation, Vector3.up, 100f);
+                    Singleton<EffectManager>.instance.DispatchEffect(campusLevelupEffect, instance3, spawnArea,
+                        Vector3.zero, 0.0f, 1f, Singleton<AudioManager>.instance.DefaultGroup);
+                }
+            }
+
+            // Refresh panels
+            ThreadHelper.dispatcher.Dispatch(() =>
+            {
+                List<byte> activeAreas =
+                    ReflectionHelper.GetAttr<List<byte>>(typeof(DistrictManager), "m_activeCampusAreas");
+                UIView.library.Get<AcademicYearReportPanel>("AcademicYearReportPanel").PopupPanel(activeAreas, 0, false);
+                CampusWorldInfoPanel campusWorldInfoPanel = UIView.library.Get<CampusWorldInfoPanel>("CampusWorldInfoPanel");
+                if (!campusWorldInfoPanel.component.isVisible)
+                    return;
+                campusWorldInfoPanel.OnAcademicYearEnded();
+            });
+        }
+    }
+}

--- a/src/basegame/Commands/Handler/Campus/SetAcademicStaffCountHandler.cs
+++ b/src/basegame/Commands/Handler/Campus/SetAcademicStaffCountHandler.cs
@@ -1,0 +1,26 @@
+using ColossalFramework;
+using ColossalFramework.UI;
+using CSM.API.Commands;
+using CSM.API.Helpers;
+using CSM.BaseGame.Commands.Data.Campus;
+using CSM.BaseGame.Helpers;
+
+namespace CSM.BaseGame.Commands.Handler.Campus
+{
+    public class SetAcademicStaffCountHandler : CommandHandler<SetAcademicStaffCountCommand>
+    {
+        protected override void Handle(SetAcademicStaffCountCommand command)
+        {
+            Singleton<DistrictManager>.instance.m_parks.m_buffer[command.Campus].m_academicStaffCount = command.Count;
+
+            // Refresh panel
+            if (InfoPanelHelper.IsPark(typeof(CampusWorldInfoPanel), command.Campus, out WorldInfoPanel panel))
+            {
+                SimulationManager.instance.m_ThreadingWrapper.QueueMainThread(() =>
+                {
+                    ReflectionHelper.Call((CampusWorldInfoPanel)panel, "OnSetTarget");
+                });
+            }
+        }
+    }
+}

--- a/src/basegame/Commands/Handler/Campus/SetCheerleadingBudgetHandler.cs
+++ b/src/basegame/Commands/Handler/Campus/SetCheerleadingBudgetHandler.cs
@@ -1,0 +1,31 @@
+using ColossalFramework;
+using CSM.API.Commands;
+using CSM.API.Helpers;
+using CSM.BaseGame.Commands.Data.Campus;
+using CSM.BaseGame.Helpers;
+
+namespace CSM.BaseGame.Commands.Handler.Campus
+{
+    public class SetCheerleadingBudgetHandler : CommandHandler<SetCheerleadingBudgetCommand>
+    {
+        protected override void Handle(SetCheerleadingBudgetCommand command)
+        {
+            int oldBonus = Singleton<DistrictManager>.instance.m_parks.m_buffer[command.Campus].CalculateCheerleadingAttractivenessBonus();
+
+            Singleton<DistrictManager>.instance.m_parks.m_buffer[command.Campus].m_cheerleadingBudget = command.Budget;
+
+            int newBonus = Singleton<DistrictManager>.instance.m_parks.m_buffer[command.Campus].CalculateCheerleadingAttractivenessBonus();
+            int bonus = newBonus - oldBonus;
+            Singleton<DistrictManager>.instance.m_parks.m_buffer[command.Campus].ModifyStaticAttractiveness(bonus);
+
+            // Refresh panel
+            if (InfoPanelHelper.IsPark(typeof(CampusWorldInfoPanel), command.Campus, out WorldInfoPanel panel))
+            {
+                SimulationManager.instance.m_ThreadingWrapper.QueueMainThread(() =>
+                {
+                    ReflectionHelper.Call((CampusWorldInfoPanel)panel, "OnSetTarget");
+                });
+            }
+        }
+    }
+}

--- a/src/basegame/Commands/Handler/Campus/SetCoachesCountHandler.cs
+++ b/src/basegame/Commands/Handler/Campus/SetCoachesCountHandler.cs
@@ -1,0 +1,26 @@
+using ColossalFramework;
+using CSM.API.Commands;
+using CSM.API.Helpers;
+using CSM.BaseGame.Commands.Data.Campus;
+using CSM.BaseGame.Helpers;
+
+namespace CSM.BaseGame.Commands.Handler.Campus
+{
+    public class SetCoachesCountHandler : CommandHandler<SetCoachesCountCommand>
+    {
+        protected override void Handle(SetCoachesCountCommand command)
+        {
+            Singleton<DistrictManager>.instance.m_parks.m_buffer[command.Campus].m_coachHireTimes = command.CoachHireTimes;
+            Singleton<DistrictManager>.instance.m_parks.m_buffer[command.Campus].m_coachCount = command.Count;
+
+            // Refresh panel
+            if (InfoPanelHelper.IsPark(typeof(CampusWorldInfoPanel), command.Campus, out WorldInfoPanel panel))
+            {
+                SimulationManager.instance.m_ThreadingWrapper.QueueMainThread(() =>
+                {
+                    ReflectionHelper.Call((CampusWorldInfoPanel)panel, "OnSetTarget");
+                });
+            }
+        }
+    }
+}

--- a/src/basegame/Commands/Handler/Campus/SetTicketPriceHandler.cs
+++ b/src/basegame/Commands/Handler/Campus/SetTicketPriceHandler.cs
@@ -1,0 +1,25 @@
+using ColossalFramework;
+using CSM.API.Commands;
+using CSM.API.Helpers;
+using CSM.BaseGame.Commands.Data.Campus;
+using CSM.BaseGame.Helpers;
+
+namespace CSM.BaseGame.Commands.Handler.Campus
+{
+    public class SetTicketPriceHandler : CommandHandler<SetTicketPriceCommand>
+    {
+        protected override void Handle(SetTicketPriceCommand command)
+        {
+            Singleton<DistrictManager>.instance.m_parks.m_buffer[command.Campus].m_ticketPrice = command.Price;
+
+            // Refresh panel
+            if (InfoPanelHelper.IsPark(typeof(CampusWorldInfoPanel), command.Campus, out WorldInfoPanel panel))
+            {
+                SimulationManager.instance.m_ThreadingWrapper.QueueMainThread(() =>
+                {
+                    ReflectionHelper.Call((CampusWorldInfoPanel)panel, "OnSetTarget");
+                });
+            }
+        }
+    }
+}

--- a/src/basegame/Commands/Handler/Campus/SetVarsityColorHandler.cs
+++ b/src/basegame/Commands/Handler/Campus/SetVarsityColorHandler.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using ColossalFramework;
+using CSM.API;
+using CSM.API.Commands;
+using CSM.API.Helpers;
+using CSM.BaseGame.Commands.Data.Campus;
+using CSM.BaseGame.Helpers;
+using UnityEngine;
+
+namespace CSM.BaseGame.Commands.Handler.Campus
+{
+    public class SetVarsityColorHandler : CommandHandler<SetVarsityColorCommand>
+    {
+        protected override void Handle(SetVarsityColorCommand command)
+        {
+            ref DistrictPark districtPark = ref Singleton<DistrictManager>.instance.m_parks.m_buffer[command.Campus];
+
+            // We need to set the color beforehand, as the call to SetVarsityColor will copy the park struct and not reflect the results on the object
+            districtPark.m_varsityColor = command.Color;
+            ReflectionHelper.Call(districtPark, "SetVarsityColor", command.Campus, command.Color);
+            Color newColor = Singleton<DistrictManager>.instance.m_parks.m_buffer[command.Campus].m_varsityColor;
+
+            // Refresh panel if is campus
+            if (InfoPanelHelper.IsPark(typeof(CampusWorldInfoPanel), command.Campus, out WorldInfoPanel panel))
+            {
+                SimulationManager.instance.m_ThreadingWrapper.QueueMainThread(() =>
+                {
+                    ReflectionHelper.Call((CampusWorldInfoPanel)panel, "OnSetTarget");
+                });
+            }
+        }
+    }
+}

--- a/src/basegame/Commands/Handler/Campus/SetVarsityColorHandler.cs
+++ b/src/basegame/Commands/Handler/Campus/SetVarsityColorHandler.cs
@@ -18,7 +18,6 @@ namespace CSM.BaseGame.Commands.Handler.Campus
             // We need to set the color beforehand, as the call to SetVarsityColor will copy the park struct and not reflect the results on the object
             districtPark.m_varsityColor = command.Color;
             ReflectionHelper.Call(districtPark, "SetVarsityColor", command.Campus, command.Color);
-            Color newColor = Singleton<DistrictManager>.instance.m_parks.m_buffer[command.Campus].m_varsityColor;
 
             // Refresh panel if is campus
             if (InfoPanelHelper.IsPark(typeof(CampusWorldInfoPanel), command.Campus, out WorldInfoPanel panel))

--- a/src/basegame/Commands/Handler/Campus/SetVarsityIdentityHandler.cs
+++ b/src/basegame/Commands/Handler/Campus/SetVarsityIdentityHandler.cs
@@ -1,0 +1,31 @@
+using ColossalFramework;
+using CSM.API.Commands;
+using CSM.API.Helpers;
+using CSM.BaseGame.Commands.Data.Campus;
+using CSM.BaseGame.Helpers;
+
+namespace CSM.BaseGame.Commands.Handler.Campus
+{
+    public class SetVarsityIdentityHandler : CommandHandler<SetVarsityIdentityCommand>
+    {
+        protected override void Handle(SetVarsityIdentityCommand command)
+        {
+            ref DistrictPark districtPark = ref Singleton<DistrictManager>.instance.m_parks.m_buffer[command.Campus];
+
+            // We need to set the values beforehand, as the call to SetVarsityIdentity will copy the park struct and not reflect the results on the object
+            districtPark.m_varsityIdentityIndex = command.Identity;
+            districtPark.m_eventPolicies &= ~(DistrictPolicies.Event.Team01Ad | DistrictPolicies.Event.Team02Ad | DistrictPolicies.Event.Team03Ad | DistrictPolicies.Event.Team04Ad | DistrictPolicies.Event.Team05Ad | DistrictPolicies.Event.Team06Ad | DistrictPolicies.Event.Team07Ad);
+            districtPark.m_eventPolicies |= DistrictPark.TeamToEventPolicy((DistrictPark.Team) command.Identity);
+            ReflectionHelper.Call(districtPark, "SetVarsityIdentity", command.Campus, command.Identity);
+
+            // Refresh panel if is campus
+            if (InfoPanelHelper.IsPark(typeof(CampusWorldInfoPanel), command.Campus, out WorldInfoPanel panel))
+            {
+                SimulationManager.instance.m_ThreadingWrapper.QueueMainThread(() =>
+                {
+                    ReflectionHelper.Call((CampusWorldInfoPanel)panel, "OnSetTarget");
+                });
+            }
+        }
+    }
+}

--- a/src/basegame/Commands/Handler/Districts/DistrictChangeStyleHandler.cs
+++ b/src/basegame/Commands/Handler/Districts/DistrictChangeStyleHandler.cs
@@ -15,10 +15,9 @@ namespace CSM.BaseGame.Commands.Handler.Districts
 
             if (InfoPanelHelper.IsDistrict(typeof(DistrictWorldInfoPanel), command.DistrictId, out WorldInfoPanel panel))
             {
-                DistrictWorldInfoPanel districtPanel = (DistrictWorldInfoPanel)panel;
                 SimulationManager.instance.m_ThreadingWrapper.QueueMainThread(() =>
                 {
-                    ReflectionHelper.GetAttr<UIDropDown>(districtPanel, "m_Style").selectedIndex = command.Style;
+                    ReflectionHelper.GetAttr<UIDropDown>((DistrictWorldInfoPanel)panel, "m_Style").selectedIndex = command.Style;
                 });
             }
         }

--- a/src/basegame/Commands/Handler/Districts/DistrictChangeStyleHandler.cs
+++ b/src/basegame/Commands/Handler/Districts/DistrictChangeStyleHandler.cs
@@ -1,0 +1,26 @@
+﻿using ColossalFramework;
+using ColossalFramework.UI;
+using CSM.API.Commands;
+using CSM.API.Helpers;
+using CSM.BaseGame.Commands.Data.Districts;
+using CSM.BaseGame.Helpers;
+
+namespace CSM.BaseGame.Commands.Handler.Districts
+{
+    public class DistrictChangeStyleHandler : CommandHandler<DistrictChangeStyleCommand>
+    {
+        protected override void Handle(DistrictChangeStyleCommand command)
+        {
+            Singleton<DistrictManager>.instance.m_districts.m_buffer[command.DistrictId].m_Style = command.Style;
+
+            if (InfoPanelHelper.IsDistrict(typeof(DistrictWorldInfoPanel), command.DistrictId, out WorldInfoPanel panel))
+            {
+                DistrictWorldInfoPanel districtPanel = (DistrictWorldInfoPanel)panel;
+                SimulationManager.instance.m_ThreadingWrapper.QueueMainThread(() =>
+                {
+                    ReflectionHelper.GetAttr<UIDropDown>(districtPanel, "m_Style").selectedIndex = command.Style;
+                });
+            }
+        }
+    }
+}

--- a/src/basegame/Commands/Handler/Districts/DistrictPolicyHandler.cs
+++ b/src/basegame/Commands/Handler/Districts/DistrictPolicyHandler.cs
@@ -1,6 +1,7 @@
 ﻿using CSM.API.Commands;
 using CSM.API.Helpers;
 using CSM.BaseGame.Commands.Data.Districts;
+using CSM.BaseGame.Helpers;
 
 namespace CSM.BaseGame.Commands.Handler.Districts
 {
@@ -9,7 +10,23 @@ namespace CSM.BaseGame.Commands.Handler.Districts
         protected override void Handle(DistrictPolicyCommand command)
         {
             IgnoreHelper.Instance.StartIgnore();
-            DistrictManager.instance.SetDistrictPolicy(command.Policy, command.DistrictId);
+            if (command.IsPark)
+            {
+                DistrictManager.instance.SetParkPolicy(command.Policy, command.DistrictId);
+
+                // Refresh panel if is campus
+                if (InfoPanelHelper.IsPark(typeof(CampusWorldInfoPanel), command.DistrictId, out WorldInfoPanel panel))
+                {
+                    SimulationManager.instance.m_ThreadingWrapper.QueueMainThread(() =>
+                    {
+                        ReflectionHelper.Call((CampusWorldInfoPanel)panel, "OnSetTarget");
+                    });
+                }
+            }
+            else
+            {
+                DistrictManager.instance.SetDistrictPolicy(command.Policy, command.DistrictId);
+            }
             IgnoreHelper.Instance.EndIgnore();
         }
     }

--- a/src/basegame/Commands/Handler/Districts/DistrictPolicyUnsetHandler.cs
+++ b/src/basegame/Commands/Handler/Districts/DistrictPolicyUnsetHandler.cs
@@ -1,6 +1,7 @@
 ﻿using CSM.API.Commands;
 using CSM.API.Helpers;
 using CSM.BaseGame.Commands.Data.Districts;
+using CSM.BaseGame.Helpers;
 
 namespace CSM.BaseGame.Commands.Handler.Districts
 {
@@ -9,7 +10,23 @@ namespace CSM.BaseGame.Commands.Handler.Districts
         protected override void Handle(DistrictPolicyUnsetCommand command)
         {
             IgnoreHelper.Instance.StartIgnore();
-            DistrictManager.instance.UnsetDistrictPolicy(command.Policy, command.DistrictId);
+            if (command.IsPark)
+            {
+                DistrictManager.instance.UnsetParkPolicy(command.Policy, command.DistrictId);
+
+                // Refresh panel if is campus
+                if (InfoPanelHelper.IsPark(typeof(CampusWorldInfoPanel), command.DistrictId, out WorldInfoPanel panel))
+                {
+                    SimulationManager.instance.m_ThreadingWrapper.QueueMainThread(() =>
+                    {
+                        ReflectionHelper.Call((CampusWorldInfoPanel)panel, "OnSetTarget");
+                    });
+                }
+            }
+            else
+            {
+                DistrictManager.instance.UnsetDistrictPolicy(command.Policy, command.DistrictId);
+            }
             IgnoreHelper.Instance.EndIgnore();
         }
     }

--- a/src/basegame/Commands/Handler/Events/EventSetResultHandler.cs
+++ b/src/basegame/Commands/Handler/Events/EventSetResultHandler.cs
@@ -1,0 +1,23 @@
+using CSM.API.Commands;
+using CSM.BaseGame.Commands.Data.Events;
+
+namespace CSM.BaseGame.Commands.Handler.Events
+{
+    public class EventSetResultHandler : CommandHandler<EventSetResultCommand>
+    {
+        protected override void Handle(EventSetResultCommand command)
+        {
+            ref EventData data = ref EventManager.instance.m_events.m_buffer[command.Event];
+            if (command.Result)
+            {
+                data.m_flags |= EventData.Flags.Success;
+                data.m_flags &= ~EventData.Flags.Failure;
+            }
+            else
+            {
+                data.m_flags |= EventData.Flags.Failure;
+                data.m_flags &= ~EventData.Flags.Success;
+            }
+        }
+    }
+}

--- a/src/basegame/Commands/Handler/Events/EventSetTicketPriceHandler.cs
+++ b/src/basegame/Commands/Handler/Events/EventSetTicketPriceHandler.cs
@@ -21,7 +21,7 @@ namespace CSM.BaseGame.Commands.Handler.Events
 
                 SimulationManager.instance.m_ThreadingWrapper.QueueMainThread(() =>
                 {
-                    slider.value = command.Price;
+                    slider.value = command.Price / 100f;
                 });
             }
 

--- a/src/basegame/Helpers/InfoPanelHelper.cs
+++ b/src/basegame/Helpers/InfoPanelHelper.cs
@@ -30,6 +30,18 @@ namespace CSM.BaseGame.Helpers
             return instance.Type == InstanceType.Building && instance.Building == buildingId;
         }
 
+        public static bool IsPark(Type panelType, byte parkId, out WorldInfoPanel panel)
+        {
+            InstanceID instance = GetInstanceID(panelType, out panel);
+            return instance.Type == InstanceType.Park && instance.Park == parkId;
+        }
+
+        public static bool IsDistrict(Type panelType, byte districtId, out WorldInfoPanel panel)
+        {
+            InstanceID instance = GetInstanceID(panelType, out panel);
+            return instance.Type == InstanceType.District && instance.District == districtId;
+        }
+
         public static bool IsEventBuilding(Type panelType, ushort eventId, out WorldInfoPanel panel)
         {
             InstanceID instance = GetInstanceID(panelType, out panel);

--- a/src/basegame/Injections/CampusHandler.cs
+++ b/src/basegame/Injections/CampusHandler.cs
@@ -214,12 +214,12 @@ namespace CSM.BaseGame.Injections
     {
         public static void Prefix()
         {
-            IgnoreHelper.Instance.StartIgnore("SetTarget");
+            IgnoreHelper.Instance.StartIgnore();
         }
 
         public static void Postfix()
         {
-            IgnoreHelper.Instance.EndIgnore("SetTarget");
+            IgnoreHelper.Instance.EndIgnore();
         }
     }
 }

--- a/src/basegame/Injections/CampusHandler.cs
+++ b/src/basegame/Injections/CampusHandler.cs
@@ -1,0 +1,179 @@
+using System;
+using ColossalFramework;
+using CSM.API.Commands;
+using CSM.API.Helpers;
+using CSM.BaseGame.Commands.Data.Campus;
+using HarmonyLib;
+using UnityEngine;
+
+namespace CSM.BaseGame.Injections
+{
+    [HarmonyPatch(typeof(CampusWorldInfoPanel))]
+    [HarmonyPatch("OnBuyResearchGrant")]
+    public class OnBuyResearchGrant
+    {
+        public static void Postfix(InstanceID ___m_InstanceID)
+        {
+            if (IgnoreHelper.Instance.IsIgnored())
+                return;
+
+            byte park = ___m_InstanceID.Park;
+            byte grantType = Singleton<DistrictManager>.instance.m_parks.m_buffer[park].m_grantType;
+            Command.SendToAll(new BuyResearchGrantCommand
+            {
+                Campus = park,
+                GrantType = grantType
+            });
+        }
+    }
+
+    [HarmonyPatch(typeof(CampusWorldInfoPanel))]
+    [HarmonyPatch("OnAcademicStaffValueChanged")]
+    public class OnAcademicStaffValueChanged
+    {
+        public static void Prefix(InstanceID ___m_InstanceID, float value)
+        {
+            if (IgnoreHelper.Instance.IsIgnored())
+                return;
+
+            byte park = ___m_InstanceID.Park;
+            if (Singleton<DistrictManager>.instance.m_parks.m_buffer[park].m_academicStaffCount != (byte)value)
+            {
+                Command.SendToAll(new SetAcademicStaffCountCommand
+                {
+                    Campus = park,
+                    Count = (byte) value
+                });
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(CampusWorldInfoPanel))]
+    [HarmonyPatch("OnCoachesCountChanged")]
+    public class OnCoachesCountChanged
+    {
+        public static void Prefix(InstanceID ___m_InstanceID, float value)
+        {
+            byte park = ___m_InstanceID.Park;
+            _sendPacket = Singleton<DistrictManager>.instance.m_parks.m_buffer[park].m_academicStaffCount !=
+                          (byte)value;
+        }
+
+        public static void Postfix(InstanceID ___m_InstanceID, float value)
+        {
+            if (!_sendPacket || IgnoreHelper.Instance.IsIgnored())
+                return;
+
+            byte park = ___m_InstanceID.Park;
+            DateTime[] coachHireTimes = Singleton<DistrictManager>.instance.m_parks.m_buffer[park].m_coachHireTimes;
+            Command.SendToAll(new SetCoachesCountCommand
+            {
+                Campus = park,
+                Count = (byte) value,
+                CoachHireTimes = coachHireTimes
+            });
+        }
+
+        private static bool _sendPacket;
+    }
+
+    [HarmonyPatch(typeof(CampusWorldInfoPanel))]
+    [HarmonyPatch("OnCheerleadingBudgetChanged")]
+    public class OnCheerleadingBudgetChanged
+    {
+        public static void Prefix(InstanceID ___m_InstanceID, float value)
+        {
+            if (IgnoreHelper.Instance.IsIgnored())
+                return;
+
+            byte park = ___m_InstanceID.Park;
+            if (Singleton<DistrictManager>.instance.m_parks.m_buffer[park].m_cheerleadingBudget != (int)value)
+            {
+                Command.SendToAll(new SetCheerleadingBudgetCommand
+                {
+                    Campus = park,
+                    Budget = (int)value
+                });
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(CampusWorldInfoPanel))]
+    [HarmonyPatch("OnTicketPriceChanged")]
+    public class OnTicketPriceChanged
+    {
+        public static void Prefix(InstanceID ___m_InstanceID, float value)
+        {
+            if (IgnoreHelper.Instance.IsIgnored())
+                return;
+
+            byte park = ___m_InstanceID.Park;
+            ushort newPrice = (ushort)(value * 100.0);
+            if (Singleton<DistrictManager>.instance.m_parks.m_buffer[park].m_ticketPrice != newPrice)
+            {
+                Command.SendToAll(new SetTicketPriceCommand
+                {
+                    Campus = park,
+                    Price = newPrice
+                });
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(CampusWorldInfoPanel))]
+    [HarmonyPatch("OnVarsityIdentityChanged")]
+    public class OnVarsityIdentityChanged
+    {
+        public static void Prefix(InstanceID ___m_InstanceID, int value)
+        {
+            if (IgnoreHelper.Instance.IsIgnored())
+                return;
+
+            byte park = ___m_InstanceID.Park;
+            if (Singleton<DistrictManager>.instance.m_parks.m_buffer[park].m_varsityIdentityIndex != value)
+            {
+                Command.SendToAll(new SetVarsityIdentityCommand
+                {
+                    Campus = park,
+                    Identity = value
+                });
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(CampusWorldInfoPanel))]
+    [HarmonyPatch("OnVarsityColorChanged")]
+    public class OnVarsityColorChanged
+    {
+        public static void Prefix(InstanceID ___m_InstanceID, Color value)
+        {
+            if (IgnoreHelper.Instance.IsIgnored())
+                return;
+
+            byte park = ___m_InstanceID.Park;
+            if (Singleton<DistrictManager>.instance.m_parks.m_buffer[park].m_varsityColor != value)
+            {
+                Command.SendToAll(new SetVarsityColorCommand
+                {
+                    Campus = park,
+                    Color = value
+                });
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(CampusWorldInfoPanel))]
+    [HarmonyPatch("OnSetTarget")]
+    public class OnSetTarget
+    {
+        public static void Prefix()
+        {
+            IgnoreHelper.Instance.StartIgnore();
+        }
+
+        public static void Postfix()
+        {
+            IgnoreHelper.Instance.EndIgnore();
+        }
+    }
+}

--- a/src/basegame/Injections/DistrictHandler.cs
+++ b/src/basegame/Injections/DistrictHandler.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using ColossalFramework;
 using ColossalFramework.Threading;
+using CSM.API;
 using CSM.API.Commands;
 using CSM.API.Helpers;
 using CSM.BaseGame.Commands.Data.Districts;

--- a/src/basegame/Injections/DistrictHandler.cs
+++ b/src/basegame/Injections/DistrictHandler.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Reflection;
+using ColossalFramework;
+using ColossalFramework.Threading;
 using CSM.API.Commands;
 using CSM.API.Helpers;
 using CSM.BaseGame.Commands.Data.Districts;
@@ -78,7 +81,8 @@ namespace CSM.BaseGame.Injections
                 Command.SendToAll(new DistrictPolicyCommand
                 {
                     Policy = policy,
-                    DistrictId = district
+                    DistrictId = district,
+                    IsPark = false
                 });
             }
         }
@@ -101,6 +105,24 @@ namespace CSM.BaseGame.Injections
     }
 
     [HarmonyPatch(typeof(DistrictManager))]
+    [HarmonyPatch("SetParkPolicy")]
+    public class SetParkPolicy
+    {
+        public static void Postfix(DistrictPolicies.Policies policy, byte park)
+        {
+            if (!IgnoreHelper.Instance.IsIgnored())
+            {
+                Command.SendToAll(new DistrictPolicyCommand
+                {
+                    Policy = policy,
+                    DistrictId = park,
+                    IsPark = true
+                });
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(DistrictManager))]
     [HarmonyPatch("UnsetDistrictPolicy")]
     public class UnsetDistrictPolicy
     {
@@ -111,7 +133,8 @@ namespace CSM.BaseGame.Injections
                 Command.SendToAll(new DistrictPolicyUnsetCommand
                 {
                     Policy = policy,
-                    DistrictId = district
+                    DistrictId = district,
+                    IsPark = false
                 });
             }
         }
@@ -128,6 +151,24 @@ namespace CSM.BaseGame.Injections
                 Command.SendToAll(new DistrictCityPolicyUnsetCommand
                 {
                     Policy = policy,
+                });
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(DistrictManager))]
+    [HarmonyPatch("UnsetParkPolicy")]
+    public class UnsetParkPolicy
+    {
+        public static void Postfix(DistrictPolicies.Policies policy, byte park)
+        {
+            if (!IgnoreHelper.Instance.IsIgnored())
+            {
+                Command.SendToAll(new DistrictPolicyUnsetCommand
+                {
+                    Policy = policy,
+                    DistrictId = park,
+                    IsPark = true
                 });
             }
         }
@@ -167,6 +208,48 @@ namespace CSM.BaseGame.Injections
                     ParkId = park
                 });
             }
+        }
+    }
+
+    [HarmonyPatch(typeof(DistrictWorldInfoPanel))]
+    [HarmonyPatch("OnStyleChanged")]
+    public class StyleChanged
+    {
+        public static void Prefix(DistrictWorldInfoPanel __instance, int value)
+        {
+            byte district = ReflectionHelper.GetAttr<InstanceID>(__instance, "m_InstanceID").District;
+            ushort oldStyle = Singleton<DistrictManager>.instance.m_districts.m_buffer[district].m_Style;
+            if (oldStyle != value)
+            {
+                Command.SendToAll(new DistrictChangeStyleCommand
+                {
+                    Style = (ushort) value,
+                    DistrictId = district
+                });
+            }
+        }
+    }
+
+    // Fix exception caused by cities in some cases in this method:
+    [HarmonyPatch(typeof(DistrictWorldInfoPanel))]
+    [HarmonyPatch("OnPoliciesChanged")]
+    public class OnPoliciesChanged
+    {
+        public static bool Prefix(DistrictWorldInfoPanel __instance)
+        {
+            MethodInfo updatePolicies = typeof(DistrictWorldInfoPanel).GetMethod("UpdatePolicies", ReflectionHelper.AllAccessFlags);
+
+            // If we are already in the correct thread, call directly
+            if (ThreadHelper.dispatcher == Dispatcher.currentSafe)
+            {
+                updatePolicies.Invoke(__instance, new object[0]);
+            }
+            else
+            {
+                ThreadHelper.dispatcher.Dispatch(() => updatePolicies.Invoke(__instance, new object[0]));
+            }
+
+            return false;
         }
     }
 }

--- a/src/csm/CSM.csproj
+++ b/src/csm/CSM.csproj
@@ -135,7 +135,9 @@
 		<Compile Include="Injections\PauseMenuHandler.cs" />
 		<Compile Include="Injections\SpeedPauseHandler.cs" />
 		<Compile Include="Injections\TickLoopHandler.cs" />
+		<Compile Include="Models\AcademicWorksDataSurrogate.cs" />
 		<Compile Include="Models\ColorSurrogate.cs" />
+		<Compile Include="Models\DistrictYearReportDataSurrogate.cs" />
 		<Compile Include="Models\QuaternionSurrogate.cs" />
 		<Compile Include="Models\ControlPointSurrogate.cs" />
 		<Compile Include="Models\InstanceIDSurrogate.cs" />

--- a/src/csm/Commands/CommandInternal.cs
+++ b/src/csm/Commands/CommandInternal.cs
@@ -197,7 +197,7 @@ namespace CSM.Commands
             _cmdMapping.Clear();
             try
             {
-                // First, find all CSM classes, then the other mods. This is necessary to 
+                // First, find all CSM classes, then the other mods. This is necessary to
                 // ensure that our management packets have always the same ids,
                 // as for example the ConnectionRequest and ConnectionResult commands are used
                 // to determine the installed mods.
@@ -228,6 +228,9 @@ namespace CSM.Commands
                 model[typeof(Color)].SetSurrogate(typeof(ColorSurrogate));
 
                 model[typeof(InstanceID)].SetSurrogate(typeof(InstanceIDSurrogate));
+
+                model[typeof(AcademicWorksData)].SetSurrogate(typeof(AcademicWorksDataSurrogate));
+                model[typeof(DistrictYearReportData)].SetSurrogate(typeof(DistrictYearReportDataSurrogate));
 
                 // Add base command to the protobuf model with all attributes
                 model.Add(typeof(CommandBase), true);

--- a/src/csm/Helpers/DLCHelper.cs
+++ b/src/csm/Helpers/DLCHelper.cs
@@ -54,7 +54,7 @@ namespace CSM.Helpers
                 case SteamHelper.DLC.AirportDLC:
                     return ModSupportType.Unknown;
                 case SteamHelper.DLC.CampusDLC:
-                    return ModSupportType.Unknown;
+                    return ModSupportType.Supported;
                 case SteamHelper.DLC.MusicFestival: // Concerts
                     return ModSupportType.Unknown;
                 case SteamHelper.DLC.FinancialDistrictsDLC:

--- a/src/csm/Helpers/DLCHelper.cs
+++ b/src/csm/Helpers/DLCHelper.cs
@@ -1,10 +1,13 @@
+using CSM.Mods;
+
 namespace CSM.Helpers
 {
     public static class DLCHelper
     {
         public static SteamHelper.ExpansionBitMask GetOwnedExpansions()
         {
-            return SteamHelper.GetOwnedExpansionMask();
+            // Ignore christmas as it is only music related, but not in the radio station bit mask :/
+            return SteamHelper.GetOwnedExpansionMask() & ~SteamHelper.ExpansionBitMask.Christmas;
         }
 
         public static SteamHelper.ModderPackBitMask GetOwnedModderPacks()
@@ -21,6 +24,91 @@ namespace CSM.Helpers
                 ServerMissingModderPack = ~serverModderPack & clientModderPack,
                 ClientMissingModderPack = serverModderPack & ~clientModderPack,
             };
+        }
+
+        public static string GetDlcName(SteamHelper.DLC dlc)
+        {
+            DLCList dlcPanel = UnityEngine.Object.FindObjectOfType<DLCList>();
+            return GetDlcName(dlcPanel, dlc);
+        }
+
+        public static string GetDlcName(DLCList list, SteamHelper.DLC dlc)
+        {
+            string dlcName = list.FindLocalizedDLCName(dlc);
+            if (string.IsNullOrEmpty(dlcName))
+            {
+                // Default to enum item name
+                dlcName = dlc.ToString();
+            }
+
+            return dlcName;
+        }
+
+        public static ModSupportType GetSupport(SteamHelper.DLC dlc)
+        {
+            switch (dlc)
+            {
+                // DLCs
+                case SteamHelper.DLC.AfterDarkDLC:
+                    return ModSupportType.Unknown;
+                case SteamHelper.DLC.AirportDLC:
+                    return ModSupportType.Unknown;
+                case SteamHelper.DLC.CampusDLC:
+                    return ModSupportType.Unknown;
+                case SteamHelper.DLC.MusicFestival: // Concerts
+                    return ModSupportType.Unknown;
+                case SteamHelper.DLC.FinancialDistrictsDLC:
+                    return ModSupportType.Unknown;
+                case SteamHelper.DLC.GreenCitiesDLC:
+                    return ModSupportType.Unknown;
+                case SteamHelper.DLC.HotelDLC:
+                    return ModSupportType.Unknown;
+                case SteamHelper.DLC.IndustryDLC:
+                    return ModSupportType.Unknown;
+                case SteamHelper.DLC.InMotionDLC: // Mass transit
+                    return ModSupportType.Unknown;
+                case SteamHelper.DLC.Football: // Match day
+                    return ModSupportType.Supported;
+                case SteamHelper.DLC.NaturalDisastersDLC:
+                    return ModSupportType.Unsupported;
+                case SteamHelper.DLC.ParksDLC:
+                    return ModSupportType.Unknown;
+                case SteamHelper.DLC.PlazasAndPromenadesDLC:
+                    return ModSupportType.Unknown;
+                case SteamHelper.DLC.SnowFallDLC:
+                    return ModSupportType.Supported;
+                case SteamHelper.DLC.UrbanDLC: // Sunset Harbor
+                    return ModSupportType.Unknown;
+
+                // Cosmetics
+                case SteamHelper.DLC.DeluxeDLC:
+                case SteamHelper.DLC.Football2345:
+                case SteamHelper.DLC.ModderPack1:
+                case SteamHelper.DLC.ModderPack2:
+                case SteamHelper.DLC.ModderPack3:
+                case SteamHelper.DLC.ModderPack4:
+                case SteamHelper.DLC.ModderPack5:
+                case SteamHelper.DLC.ModderPack6:
+                case SteamHelper.DLC.ModderPack7:
+                case SteamHelper.DLC.ModderPack8:
+                case SteamHelper.DLC.ModderPack9:
+                case SteamHelper.DLC.ModderPack10:
+                case SteamHelper.DLC.ModderPack11:
+                case SteamHelper.DLC.ModderPack12:
+                case SteamHelper.DLC.ModderPack13:
+                case SteamHelper.DLC.ModderPack14:
+                case SteamHelper.DLC.ModderPack15:
+                case SteamHelper.DLC.ModderPack16:
+                case SteamHelper.DLC.ModderPack17:
+                case SteamHelper.DLC.ModderPack18:
+                case SteamHelper.DLC.ModderPack19:
+                case SteamHelper.DLC.ModderPack20:
+                case SteamHelper.DLC.ModderPack21:
+                case SteamHelper.DLC.OrientalBuildings:
+                    return ModSupportType.Supported;
+                default:
+                    return ModSupportType.Unknown;
+            }
         }
 
         public class DLCComparison

--- a/src/csm/Injections/PauseMenuHandler.cs
+++ b/src/csm/Injections/PauseMenuHandler.cs
@@ -67,14 +67,6 @@ namespace CSM.Injections
                     if (MultiplayerManager.Instance.CurrentRole == MultiplayerRole.None)
                     {
                         PanelManager.TogglePanel<HostGamePanel>();
-
-                        // Display warning if DLCs or other mods are enabled
-                        if (DLCHelper.GetOwnedExpansions() != SteamHelper.ExpansionBitMask.None || DLCHelper.GetOwnedModderPacks() != SteamHelper.ModderPackBitMask.None)
-                        {
-                            MessagePanel msgPanel = PanelManager.ShowPanel<MessagePanel>();
-                            if (msgPanel)
-                                msgPanel.DisplayContentWarning();
-                        }
                     }
                     else
                     {

--- a/src/csm/Models/AcademicWorksDataSurrogate.cs
+++ b/src/csm/Models/AcademicWorksDataSurrogate.cs
@@ -1,0 +1,42 @@
+using ProtoBuf;
+
+namespace CSM.Models
+{
+    [ProtoContract]
+    public class AcademicWorksDataSurrogate
+    {
+        [ProtoMember(1)]
+        public int m_worksType1 { get; set; }
+
+        [ProtoMember(2)]
+        public int m_worksType2 { get; set; }
+
+        [ProtoMember(3)]
+        public int m_worksType3 { get; set; }
+
+        [ProtoMember(4)]
+        public int WorksCount { get; set; }
+
+        public static implicit operator AcademicWorksDataSurrogate(AcademicWorksData value)
+        {
+            return new AcademicWorksDataSurrogate
+            {
+                m_worksType1 = value.m_worksType1,
+                m_worksType2 = value.m_worksType2,
+                m_worksType3 = value.m_worksType3,
+                WorksCount = value.m_worksCount
+            };
+        }
+
+        public static implicit operator AcademicWorksData(AcademicWorksDataSurrogate value)
+        {
+            return new AcademicWorksData
+            {
+                m_worksType1 = value.m_worksType1,
+                m_worksType2 = value.m_worksType2,
+                m_worksType3 = value.m_worksType3,
+                m_worksCount = value.WorksCount
+            };
+        }
+    }
+}

--- a/src/csm/Models/DistrictYearReportDataSurrogate.cs
+++ b/src/csm/Models/DistrictYearReportDataSurrogate.cs
@@ -1,0 +1,103 @@
+using CSM.API.Helpers;
+using ProtoBuf;
+// ReSharper disable InconsistentNaming
+
+namespace CSM.Models
+{
+    [ProtoContract]
+    public class DistrictYearReportDataSurrogate
+    {
+        [ProtoMember(1)]
+        private byte m_reputationLevel;
+        [ProtoMember(2)]
+        private int m_studentCount;
+        [ProtoMember(3)]
+        private int m_campusAttractiveness;
+        [ProtoMember(4)]
+        private int m_totalWorks;
+        [ProtoMember(5)]
+        private byte m_grantType;
+        [ProtoMember(6)]
+        private int m_grantWorkIndex;
+        [ProtoMember(7)]
+        private AcademicWorksData m_academicWorksData;
+        [ProtoMember(8)]
+        private ulong m_totalPrizeMoney;
+        [ProtoMember(9)]
+        private byte m_togaPartyCount;
+        [ProtoMember(10)]
+        private long m_togaPartyCurrentSeed;
+        [ProtoMember(11)]
+        private long m_togaPartySeed1;
+        [ProtoMember(12)]
+        private long m_togaPartySeed2;
+        [ProtoMember(13)]
+        private string m_milestoneUnlocked;
+        [ProtoMember(14)]
+        private ulong[] m_ticketsIncome;
+        [ProtoMember(15)]
+        private ulong[] m_winningsIncome;
+        [ProtoMember(16)]
+        private byte[] m_matchesWon;
+        [ProtoMember(17)]
+        private byte[] m_matchesLost;
+        [ProtoMember(18)]
+        private byte[] m_matchesCancelled;
+        [ProtoMember(19)]
+        private bool[] m_trophies;
+
+        public static implicit operator DistrictYearReportDataSurrogate(DistrictYearReportData value)
+        {
+            return new DistrictYearReportDataSurrogate
+            {
+                m_reputationLevel = value.m_reputationLevel,
+                m_studentCount = value.m_studentCount,
+                m_campusAttractiveness = value.m_campusAttractiveness,
+                m_totalWorks = value.m_totalWorks,
+                m_grantType = value.m_grantType,
+                m_grantWorkIndex = value.m_grantWorkIndex,
+                m_academicWorksData = value.m_academicWorksData,
+                m_totalPrizeMoney = value.m_totalPrizeMoney,
+                m_togaPartyCount = value.m_togaPartyCount,
+                m_togaPartyCurrentSeed = value.m_togaPartyCurrentSeed,
+                m_togaPartySeed1 = value.m_togaPartySeed1,
+                m_togaPartySeed2 = value.m_togaPartySeed2,
+                m_milestoneUnlocked = value.m_milestoneUnlocked,
+                m_ticketsIncome = ReflectionHelper.GetAttr<ulong[]>(value, "m_ticketsIncome"),
+                m_winningsIncome = ReflectionHelper.GetAttr<ulong[]>(value, "m_winningsIncome"),
+                m_matchesWon = ReflectionHelper.GetAttr<byte[]>(value, "m_matchesWon"),
+                m_matchesLost = ReflectionHelper.GetAttr<byte[]>(value, "m_matchesLost"),
+                m_matchesCancelled = ReflectionHelper.GetAttr<byte[]>(value, "m_matchesCancelled"),
+                m_trophies = ReflectionHelper.GetAttr<bool[]>(value, "m_trophies"),
+            };
+        }
+
+        public static implicit operator DistrictYearReportData(DistrictYearReportDataSurrogate value)
+        {
+            DistrictYearReportData data = new DistrictYearReportData
+            {
+                m_reputationLevel = value.m_reputationLevel,
+                m_studentCount = value.m_studentCount,
+                m_campusAttractiveness = value.m_campusAttractiveness,
+                m_totalWorks = value.m_totalWorks,
+                m_grantType = value.m_grantType,
+                m_grantWorkIndex = value.m_grantWorkIndex,
+                m_academicWorksData = value.m_academicWorksData,
+                m_totalPrizeMoney = value.m_totalPrizeMoney,
+                m_togaPartyCount = value.m_togaPartyCount,
+                m_togaPartyCurrentSeed = value.m_togaPartyCurrentSeed,
+                m_togaPartySeed1 = value.m_togaPartySeed1,
+                m_togaPartySeed2 = value.m_togaPartySeed2,
+                m_milestoneUnlocked = value.m_milestoneUnlocked,
+            };
+            value.m_ticketsIncome?.CopyTo(data.ticketsIncome, 0);
+            value.m_winningsIncome?.CopyTo(data.winningsIncome, 0);
+            value.m_matchesWon?.CopyTo(data.matchesWon, 0);
+            value.m_matchesLost?.CopyTo(data.matchesLost, 0);
+            value.m_matchesCancelled?.CopyTo(data.matchesCancelled, 0);
+            value.m_trophies?.CopyTo(data.trophies, 0);
+
+            return data;
+        }
+    }
+}

--- a/src/csm/Mods/ModCompat.cs
+++ b/src/csm/Mods/ModCompat.cs
@@ -66,6 +66,15 @@ namespace CSM.Mods
 
         private static IEnumerable<ModSupportStatus> GetModSupport()
         {
+            foreach (SteamHelper.DLC dlc in DLCHelper.GetOwnedExpansions().DLCs())
+            {
+                yield return new ModSupportStatus("DLC: " + DLCHelper.GetDlcName(dlc), "", DLCHelper.GetSupport(dlc), false);
+            }
+            foreach (SteamHelper.DLC dlc in DLCHelper.GetOwnedModderPacks().DLCs())
+            {
+                yield return new ModSupportStatus("DLC: " + DLCHelper.GetDlcName(dlc), "", DLCHelper.GetSupport(dlc), false);
+            }
+
             foreach (PluginManager.PluginInfo info in Singleton<PluginManager>.instance.GetPluginsInfo())
             {
                 // Skip disabled mods

--- a/src/csm/Mods/ModCompat.cs
+++ b/src/csm/Mods/ModCompat.cs
@@ -159,7 +159,7 @@ namespace CSM.Mods
             panel.AddScrollbar(modInfoPanel);
 
             panel.width = 720;
-            modInfoPanel.CreateLabel("Mod Support", new Vector2(0, 0), 340, 20);
+            modInfoPanel.CreateLabel("Mod/DLC Support", new Vector2(0, 0), 340, 20);
 
             Log.Debug($"Mod support: {string.Join(", ", modSupport.Select(m => $"{m.TypeName} ({m.Type})").ToArray())}");
             int y = -50;

--- a/src/csm/Mods/ModCompat.cs
+++ b/src/csm/Mods/ModCompat.cs
@@ -68,11 +68,13 @@ namespace CSM.Mods
         {
             foreach (SteamHelper.DLC dlc in DLCHelper.GetOwnedExpansions().DLCs())
             {
-                yield return new ModSupportStatus("DLC: " + DLCHelper.GetDlcName(dlc), "", DLCHelper.GetSupport(dlc), false);
+                string name = DLCHelper.GetDlcName(dlc);
+                yield return new ModSupportStatus("DLC: " + name, name, DLCHelper.GetSupport(dlc), false);
             }
             foreach (SteamHelper.DLC dlc in DLCHelper.GetOwnedModderPacks().DLCs())
             {
-                yield return new ModSupportStatus("DLC: " + DLCHelper.GetDlcName(dlc), "", DLCHelper.GetSupport(dlc), false);
+                string name = DLCHelper.GetDlcName(dlc);
+                yield return new ModSupportStatus("DLC: " + name, name, DLCHelper.GetSupport(dlc), false);
             }
 
             foreach (PluginManager.PluginInfo info in Singleton<PluginManager>.instance.GetPluginsInfo())

--- a/src/csm/Panels/MessagePanel.cs
+++ b/src/csm/Panels/MessagePanel.cs
@@ -87,20 +87,6 @@ namespace CSM.Panels
                 _githubButton.Hide();
         }
 
-        public void DisplayContentWarning()
-        {
-            SetTitle("Warning");
-
-            const string message = "Playing with DLCs is\n" +
-                       "currently not officially supported.\n\n" +
-                       "Try to disable them if you encounter\n" +
-                       "any issues.";
-
-            SetMessage(message);
-
-            Show(true);
-        }
-
         public void DisplayInvalidApiServer()
         {
             SetTitle("Invalid API Server");
@@ -113,18 +99,6 @@ namespace CSM.Panels
             Show(true);
         }
 
-        private string GetDlcName(DLCList list, SteamHelper.DLC dlc)
-        {
-            string dlcName = list.FindLocalizedDLCName(dlc);
-            if (string.IsNullOrEmpty(dlcName))
-            {
-                // Default to enum item name
-                dlcName = dlc.ToString();
-            }
-
-            return dlcName;
-        }
-
         public void DisplayDlcMessage(DLCHelper.DLCComparison compare)
         {
             SetTitle("DLC Mismatch");
@@ -135,13 +109,13 @@ namespace CSM.Panels
             if (compare.ClientMissingExpansions != SteamHelper.ExpansionBitMask.None || compare.ClientMissingModderPack != SteamHelper.ModderPackBitMask.None)
             {
                 message += "You are missing the following DLCs:\n";
-                message += string.Join("\n", SteamHelper.DLCs(compare.ClientMissingExpansions, compare.ClientMissingModderPack, SteamHelper.RadioBitMask.None).Select(dlc => GetDlcName(dlcPanel, dlc)).ToArray());
+                message += string.Join("\n", SteamHelper.DLCs(compare.ClientMissingExpansions, compare.ClientMissingModderPack, SteamHelper.RadioBitMask.None).Select(dlc => DLCHelper.GetDlcName(dlcPanel, dlc)).ToArray());
                 message += "\n\n";
             }
             if (compare.ServerMissingExpansions != SteamHelper.ExpansionBitMask.None || compare.ServerMissingModderPack != SteamHelper.ModderPackBitMask.None)
             {
                 message += "The server doesn't have the following DLCs:\n";
-                message += string.Join("\n", SteamHelper.DLCs(compare.ServerMissingExpansions, compare.ServerMissingModderPack, SteamHelper.RadioBitMask.None).Select(dlc => GetDlcName(dlcPanel, dlc)).ToArray());
+                message += string.Join("\n", SteamHelper.DLCs(compare.ServerMissingExpansions, compare.ServerMissingModderPack, SteamHelper.RadioBitMask.None).Select(dlc => DLCHelper.GetDlcName(dlcPanel, dlc)).ToArray());
             }
 
             message += "\n\nDLCs can be enabled/disabled via checkbox in Steam.";


### PR DESCRIPTION
General changes:
- Don't show DLC warning popup anymore
- Instead, display DLC support when starting server or joining  game (next to the mod support)
- Ignore christmas DLC when joining as it only adds music
- Sync district style (e.g. for European Suburbia Content Creator pack)
- Make IgnoreHelper thread local (otherwise the "ignore" state could overlap between simulation and UI thread)
- Detect sync problems by checking if the IgnoreHelper is still in ignoring mode after the simulation tick (in simulation thread) or if it is active in Unity engine's LateUpdate lifecycle method (in UI thread).
- This should detect (and partly fix) cases where an exception occurs between start and end ignore. 

Match Day DLC:
- Fix ticket prize synchronization
- Synchronize result of football events

Campus DLC:
- Sync all interactions in the campus management panel (buying grant, setting academic staff, cheerleading budget, coaches count, ticket prices, varsity color and varsity identity)
- Sync district park policies (=Campus Area policies and more)
- Sync campus upgrades and statistics when the academic year ends
