### PR TITLE
Add TM:PE Compatibility Logic and Notification Support for Missing Addon in CSM

### DIFF
--- a/src/api/Log.cs
+++ b/src/api/Log.cs
@@ -64,6 +64,11 @@ namespace CSM.API
             Instance.Write(message, "Warn");
         }
 
+        public static void Warn(string message, Exception ex)
+        {
+            Instance.Write($"{message}: {ex}", "Warn");
+        }
+
         public static void Info(string message)
         {
             Instance.Write(message, "Info");

--- a/src/csm/CSM.csproj
+++ b/src/csm/CSM.csproj
@@ -145,6 +145,7 @@
 		<Compile Include="Models\Vector3Surrogate.cs" />
 		<Compile Include="Mods\ModCompat.cs" />
 		<Compile Include="Mods\ModSupport.cs" />
+		<Compile Include="Mods\TmpeSupportHelper.cs" />
 		<Compile Include="Networking\Client.cs" />
 		<Compile Include="Networking\Config\ClientConfig.cs" />
 		<Compile Include="Networking\Config\ConfigData.cs" />

--- a/src/csm/Helpers/SteamHelpers.cs
+++ b/src/csm/Helpers/SteamHelpers.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 using ColossalFramework;
@@ -90,6 +91,36 @@ namespace CSM.Helpers
                 {
                     JoinFromSteam(argSplit[1], checkLoadingManager);
                 }
+            }
+        }
+
+        public static void OpenOverlayToUrl(string url)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                return;
+            }
+
+            if (CSM.IsSteamPresent && Instance != null && Instance._friendsPtr != IntPtr.Zero)
+            {
+                try
+                {
+                    SteamAPI_ISteamFriends_ActivateGameOverlayToWebPage(Instance._friendsPtr, url, EActivateGameOverlayToWebPageMode.k_EActivateGameOverlayToWebPageMode_Default);
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    Log.Warn($"Failed to open Steam overlay for {url}", ex);
+                }
+            }
+
+            try
+            {
+                Process.Start(url);
+            }
+            catch (Exception ex)
+            {
+                Log.Warn($"Failed to open url {url}", ex);
             }
         }
 
@@ -284,6 +315,14 @@ namespace CSM.Helpers
             else SteamAPI_ISteamFriends_ActivateGameOverlay_32(instancePtr, pchDialog);
         }
 
+        private static void SteamAPI_ISteamFriends_ActivateGameOverlayToWebPage(IntPtr instancePtr, string url, EActivateGameOverlayToWebPageMode mode)
+        {
+            if (_use64Bit)
+                SteamAPI_ISteamFriends_ActivateGameOverlayToWebPage_64(instancePtr, url, mode);
+            else
+                SteamAPI_ISteamFriends_ActivateGameOverlayToWebPage_32(instancePtr, url, mode);
+        }
+
         [DllImport("steam_api", EntryPoint = "SteamAPI_Init", CallingConvention = CallingConvention.Cdecl)]
         private static extern bool SteamAPI_Init_32();
 
@@ -319,6 +358,8 @@ namespace CSM.Helpers
 
         [DllImport("steam_api", EntryPoint = "SteamAPI_ISteamFriends_ActivateGameOverlay", CallingConvention = CallingConvention.Cdecl)]
         private static extern void SteamAPI_ISteamFriends_ActivateGameOverlay_32(IntPtr instancePtr, [MarshalAs(UnmanagedType.LPStr)] string pchDialog);
+        [DllImport("steam_api", EntryPoint = "SteamAPI_ISteamFriends_ActivateGameOverlayToWebPage", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void SteamAPI_ISteamFriends_ActivateGameOverlayToWebPage_32(IntPtr instancePtr, [MarshalAs(UnmanagedType.LPStr)] string url, EActivateGameOverlayToWebPageMode mode);
 
         [DllImport("steam_api64", EntryPoint = "SteamAPI_Init", CallingConvention = CallingConvention.Cdecl)]
         private static extern bool SteamAPI_Init_64();
@@ -355,5 +396,7 @@ namespace CSM.Helpers
 
         [DllImport("steam_api64", EntryPoint = "SteamAPI_ISteamFriends_ActivateGameOverlay", CallingConvention = CallingConvention.Cdecl)]
         private static extern void SteamAPI_ISteamFriends_ActivateGameOverlay_64(IntPtr instancePtr, [MarshalAs(UnmanagedType.LPStr)] string pchDialog);
+        [DllImport("steam_api64", EntryPoint = "SteamAPI_ISteamFriends_ActivateGameOverlayToWebPage", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void SteamAPI_ISteamFriends_ActivateGameOverlayToWebPage_64(IntPtr instancePtr, [MarshalAs(UnmanagedType.LPStr)] string url, EActivateGameOverlayToWebPageMode mode);
     }
 }

--- a/src/csm/Mods/TmpeSupportHelper.cs
+++ b/src/csm/Mods/TmpeSupportHelper.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+using ColossalFramework;
+using ColossalFramework.Plugins;
+using ICities;
+
+namespace CSM.Mods
+{
+    internal static class TmpeSupportHelper
+    {
+        public const string TmpeSyncWorkshopLink = "https://steamcommunity.com/sharedfiles/filedetails/?id=3600743038";
+
+        private static readonly string[] TmpeTypeNames =
+        {
+            "TrafficManager.Lifecycle.TrafficManagerMod"
+        };
+
+        private static readonly string[] TmpeSyncTypeNames =
+        {
+            "CSM.TmpeSync.Mod",
+            "CSM.TmpeSync.TmpeSyncMod"
+        };
+
+        private static bool? _hasTmpeSync;
+
+        public static bool IsTmpeMod(string typeName)
+        {
+            return !string.IsNullOrEmpty(typeName) && TmpeTypeNames.Contains(typeName);
+        }
+
+        public static bool HasTmpeSyncMod()
+        {
+            if (_hasTmpeSync.HasValue)
+            {
+                return _hasTmpeSync.Value;
+            }
+
+            foreach (PluginManager.PluginInfo info in Singleton<PluginManager>.instance.GetPluginsInfo())
+            {
+                if (!info.isEnabled)
+                {
+                    continue;
+                }
+
+                IUserMod modInstance = info.userModInstance as IUserMod;
+                string typeName = modInstance?.GetType().ToString();
+                if (IsTmpeSyncMod(typeName))
+                {
+                    _hasTmpeSync = true;
+                    return true;
+                }
+            }
+
+            _hasTmpeSync = false;
+            return false;
+        }
+
+        public static void InvalidateCache()
+        {
+            _hasTmpeSync = null;
+        }
+
+        private static bool IsTmpeSyncMod(string typeName)
+        {
+            if (string.IsNullOrEmpty(typeName))
+            {
+                return false;
+            }
+
+            if (TmpeSyncTypeNames.Contains(typeName))
+            {
+                return true;
+            }
+
+            return typeName.StartsWith("CSM.TmpeSync", StringComparison.Ordinal);
+        }
+    }
+}


### PR DESCRIPTION
I’ve opened a new pull request that includes the requested changes, since the previous one had to be discarded after the branch was deleted.

The new PR implements the updated detection logic:
- If TM:PE is enabled but the addon is not, a notification window appears, either when joining a server from the main menu or when attempting to start a server in-game, recommending installation of the addon.
- If both TM:PE and the addon are enabled, TM:PE is marked as supported.
- If the addon is missing, TM:PE is shown as unsupported.

This covers the logic discussed in the original ticket https://github.com/CitiesSkylinesMultiplayer/CSM/pull/334 @kaenganxt 
Danke dir für den Tip, ist eleganter so, thx for the tip, its more elegant that way!

My build process worked on my side, but I’m using VS Code. Please verify that it builds normally in your environment as well. I hope everything fits.

My friend and I have spent many great hours in multiplayer, and this is a way to give something back. TM:PE is an important tool for the game and integrating it makes the experience even better. So thank you for your work, @kaenganxt and many others here in the repository!